### PR TITLE
Silent tests

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@
 # Files should be compiled in the correct order.
 
 # These do not depend on other files of the Waterproof-library.
+waterproof/message.v
 waterproof/auxiliary.v
 waterproof/string_auxiliary.v
 waterproof/definitions/set_definitions.v
@@ -86,6 +87,7 @@ waterproof/AllConstructiveTactics.v
 
 # Testcases. Not needed by the end-user,
 # but used to enforce they all pass for compilation.
+waterproof/test/test_message.v
 waterproof/test/reverse_engineer/auto_hintdb_arg.v
 waterproof/test/string_auxiliary_test.v
 waterproof/test/test_auxiliary_test.v

--- a/waterproof/auxiliary.v
+++ b/waterproof/auxiliary.v
@@ -26,6 +26,8 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
 
+Require Import Waterproof.message.
+
 Module Aux.
 
 (* Defensive programming error *)
@@ -116,10 +118,10 @@ Local Ltac2 rec print_all_hyps_rec (x : (ident * constr option * constr) list) :
     match x with
     | head::tail =>
         match head with
-        | (name, dunno, type) => Message.print
+        | (name, dunno, type) => print
             (Message.concat 
                 (Message.concat (Message.of_ident name) 
-                                (Message.of_string " : "))
+                                (of_string " : "))
                 (Message.of_constr type)
             );
             print_all_hyps_rec tail
@@ -146,8 +148,8 @@ Ltac2 print_all_hyps () := print_all_hyps_rec (Control.hyps ()).
 *)
 Ltac2 print_bool (b: bool) :=
     match b with
-    | true => Message.print (Message.of_string "true")
-    | false => Message.print (Message.of_string "false")
+    | true => print (of_string "true")
+    | false => print (of_string "false")
     end.
 
 (** * ltac2_assert

--- a/waterproof/deprecated/Undesired tactics/proof_finishing_tactics.v
+++ b/waterproof/deprecated/Undesired tactics/proof_finishing_tactics.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Import Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.tactics.forward_reasoning.we_conclude_that.
 Require Import Waterproof.test_auxiliary.

--- a/waterproof/deprecated/Undesired tactics/rewrite_inequalities.v
+++ b/waterproof/deprecated/Undesired tactics/rewrite_inequalities.v
@@ -23,7 +23,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Reals.
 

--- a/waterproof/deprecated/Undesired tactics/rewrite_inequalities_test.v
+++ b/waterproof/deprecated/Undesired tactics/rewrite_inequalities_test.v
@@ -22,7 +22,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.selected_databases.
 Require Import Waterproof.set_intuition.Disabled.

--- a/waterproof/deprecated/Undesired tactics/rewrite_using.v
+++ b/waterproof/deprecated/Undesired tactics/rewrite_using.v
@@ -26,7 +26,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.tactics.forward_reasoning.forward_reasoning_aux.

--- a/waterproof/deprecated/Undesired tactics/rewrite_using_test.v
+++ b/waterproof/deprecated/Undesired tactics/rewrite_using_test.v
@@ -24,7 +24,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.load_database.All.

--- a/waterproof/deprecated/Undesired tactics/we_know.v
+++ b/waterproof/deprecated/Undesired tactics/we_know.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.test_auxiliary.

--- a/waterproof/deprecated/Undesired tactics/write_as.v
+++ b/waterproof/deprecated/Undesired tactics/write_as.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Import Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.tactics.forward_reasoning.rewrite_using.
 Require Import Waterproof.auxiliary.

--- a/waterproof/deprecated/Undesired tactics/write_as_test.v
+++ b/waterproof/deprecated/Undesired tactics/write_as_test.v
@@ -22,7 +22,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.load_database.DisableWildcard.
 
 

--- a/waterproof/deprecated/Undesired tactics/write_using.v
+++ b/waterproof/deprecated/Undesired tactics/write_using.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.tactics.forward_reasoning.rewrite_using.
 Require Import Waterproof.auxiliary.

--- a/waterproof/deprecated/Undesired tactics/write_using_test.v
+++ b/waterproof/deprecated/Undesired tactics/write_using_test.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.selected_databases.
 Require Import Waterproof.set_intuition.Disabled.

--- a/waterproof/deprecated/assume_deprecated.v
+++ b/waterproof/deprecated/assume_deprecated.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 
 Require Import Waterproof.auxiliary.

--- a/waterproof/deprecated/assume_test.v
+++ b/waterproof/deprecated/assume_test.v
@@ -22,7 +22,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Load assume.

--- a/waterproof/deprecated/deprecated_collect_db.v
+++ b/waterproof/deprecated/deprecated_collect_db.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.databases.
 
 Local Ltac2 unwrap_cons x l :=

--- a/waterproof/deprecated/load_databases_demo.v
+++ b/waterproof/deprecated/load_databases_demo.v
@@ -23,7 +23,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.selected_databases.

--- a/waterproof/deprecated/load_databases_demo.v
+++ b/waterproof/deprecated/load_databases_demo.v
@@ -29,26 +29,7 @@ Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.selected_databases.
 Require Import Waterproof.waterprove.waterprove.
 
-
-
-
-
-Ltac2 Eval print (of_string "Initial database selection is:").
-Ltac2 Eval global_database_selection. 
-
 Require Import load_database.Multiplication.
 Require Import load_database.PlusMinus.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
-
-
-
-
-
-Ltac2 Eval print (of_string "Initial search depth is:").
-Ltac2 Eval global_search_depth. 
 
 Require Import Waterproof.set_search_depth.To_1.
-Ltac2 Eval print (of_string "Current search depth is:").
-Ltac2 Eval global_search_depth.

--- a/waterproof/message.v
+++ b/waterproof/message.v
@@ -1,0 +1,56 @@
+(** * [auxiliary.v]
+Authors:
+    - Jim Portegies
+Creation date: 4 March 2023
+
+A wrapper around the Ltac2 message capabilities so that 
+a global verbosity variable can control the printing.
+
+--------------------------------------------------------------------------------
+
+This file is part of Waterproof-lib.
+
+Waterproof-lib is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Waterproof-lib is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
+*)
+
+From Ltac2 Require Import Ltac2.
+From Ltac2 Require Import Int.
+
+(** * A mutable function that controls the verbosity. *)
+Ltac2 mutable verbosity () := 0.
+
+(** * print
+
+     Only prints if the global verbosity is
+     larger than or equal to zero.
+
+     Arguments:
+          - [msg : message] The message to print
+*)
+Ltac2 print (msg : message) :=
+if (ge (verbosity ()) 0) then
+     Message.print msg
+     else ().
+
+Ltac2 of_string := Message.of_string.
+
+Ltac2 of_exn := Message.of_exn.
+
+Ltac2 concat := Message.concat.
+
+Ltac2 of_constr := Message.of_constr.
+
+Ltac2 of_ident := Message.of_ident.
+
+Ltac2 of_int := Message.of_int.

--- a/waterproof/selected_databases.v
+++ b/waterproof/selected_databases.v
@@ -30,7 +30,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Import Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.databases.
 

--- a/waterproof/set_intuition/Disabled.v
+++ b/waterproof/set_intuition/Disabled.v
@@ -26,7 +26,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.waterprove.automation_subroutine.
 
 Ltac2 Set global_enable_intuition := false.

--- a/waterproof/set_intuition/Enabled.v
+++ b/waterproof/set_intuition/Enabled.v
@@ -26,7 +26,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.waterprove.automation_subroutine.
 
 Ltac2 Set global_enable_intuition := true.

--- a/waterproof/tactics/assume.v
+++ b/waterproof/tactics/assume.v
@@ -28,7 +28,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.tactics.goal_wrappers.

--- a/waterproof/tactics/because.v
+++ b/waterproof/tactics/because.v
@@ -28,7 +28,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.auxiliary.
 Require Export Waterproof.tactics.goal_wrappers.
 Require Export Waterproof.tactics.either. (* Enable the unwrapping of the Case wrapper. *)

--- a/waterproof/tactics/choose_such_that.v
+++ b/waterproof/tactics/choose_such_that.v
@@ -26,7 +26,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Ltac2 Type exn ::= [ ChooseSuchThatError(message) ].
 

--- a/waterproof/tactics/contradiction.v
+++ b/waterproof/tactics/contradiction.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Classical.
 

--- a/waterproof/tactics/either.v
+++ b/waterproof/tactics/either.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 (* Database for 'Either ... or ...' tactic. *)
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.selected_databases.

--- a/waterproof/tactics/forward_reasoning/forward_reasoning_aux.v
+++ b/waterproof/tactics/forward_reasoning/forward_reasoning_aux.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.waterprove.waterprove.
 Require Import Waterproof.tactics.goal_to_hint.

--- a/waterproof/tactics/forward_reasoning/it_holds_that.v
+++ b/waterproof/tactics/forward_reasoning/it_holds_that.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import micromega.Lra.
 

--- a/waterproof/tactics/forward_reasoning/it_suffices_to_show.v
+++ b/waterproof/tactics/forward_reasoning/it_suffices_to_show.v
@@ -26,7 +26,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.tactics.forward_reasoning.forward_reasoning_aux.
 Require Import Waterproof.tactics.goal_wrappers.

--- a/waterproof/tactics/forward_reasoning/we_conclude_that.v
+++ b/waterproof/tactics/forward_reasoning/we_conclude_that.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.tactics.forward_reasoning.forward_reasoning_aux.
 Require Import Waterproof.waterprove.waterprove.

--- a/waterproof/tactics/goal_to_hint.v
+++ b/waterproof/tactics/goal_to_hint.v
@@ -24,6 +24,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
+
+
+Require Import Waterproof.message.
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.waterprove.automation_subroutine.
 Require Import Waterproof.tactics.goal_wrappers.
@@ -33,54 +36,54 @@ Ltac2 Type exn ::= [ GoalHintError(string) ].
 Local Ltac2 create_forall_message (v_type: constr) :=
   Message.concat
             (Message.concat
-                (Message.of_string "The goal is to show a ‘for all’-statement (∀).
+                (of_string "The goal is to show a ‘for all’-statement (∀).
 Introduce an arbitrary variable of type ")
                 (Message.of_constr v_type)
             )
-            ( Message.of_string ".
+            ( of_string ".
 Use ‘Take ... : (...).’.").
 
 Local Ltac2 create_implication_message (premise: constr) :=
     Message.concat
         (Message.concat
-            (Message.of_string "The goal is to show an implication (⇒).
+            (of_string "The goal is to show an implication (⇒).
 Assume the premise ")
             (Message.of_constr premise)
         )
-        ( Message.of_string ".
+        ( of_string ".
 Use ‘Assume that (...).’.").
 
 Local Ltac2 create_function_message (premise: constr) :=
     Message.concat
         (Message.concat
-            (Message.of_string "The goal is to construct a map (⇒).
+            (of_string "The goal is to construct a map (⇒).
 Introduce an arbitrary variable of type ")
                 (Message.of_constr premise)
             )
-            ( Message.of_string ".
+            ( of_string ".
 Use ‘Take ... : (...).’.").
 
 Local Ltac2 create_exists_message (premise: constr) :=
     Message.concat
         (Message.concat
-            (Message.of_string "The goal is to show a ‘there exists’-statement (∃).
+            (of_string "The goal is to show a ‘there exists’-statement (∃).
 Choose a specific variable of type ")
                 (Message.of_constr premise)
         )
-        ( Message.of_string ".
+        ( of_string ".
 Use ‘Choose ... := (...).’ or ‘Choose (...).’.").
 
 Local Ltac2 create_goal_wrapped_message () :=
-    Message.of_string "Follow the advice in the goal window.".
+    of_string "Follow the advice in the goal window.".
 
 Local Ltac2 create_not_message (negated_type : constr) := 
   Message.concat
      (Message.concat
          (Message.concat
-             (Message.of_string "The goal is to show a negation (¬).
+             (of_string "The goal is to show a negation (¬).
 Assume that the negated expression ") (Message.of_constr negated_type)) 
-(Message.of_string " holds, then show a contradiction."))
-(Message.of_string "
+(of_string " holds, then show a contradiction."))
+(of_string "
 Use ‘Assume that (...).’ to do the first step.").
 
 
@@ -123,10 +126,10 @@ Ltac2 goal_to_hint (g:constr) :=
         end
     | forall v:?v_type, _ => create_forall_message v_type
     | exists v:?v_type, _ => create_exists_message v_type
-    | _ /\ _ => Message.of_string
+    | _ /\ _ => of_string
 "The goal is to show a conjunction (∧).
 Show both statements, use ‘We show both statements.’"
-    | _ \/ _ => Message.of_string
+    | _ \/ _ => of_string
 "The goal is to show a disjunction (∨).
 Show one of the statements, use ‘It suffices to show that (...).’ with the dots replaced with the statement you decide to show."
     | Case.Wrapper _ _                => create_goal_wrapped_message ()
@@ -140,7 +143,7 @@ Show one of the statements, use ‘It suffices to show that (...).’ with the d
     | False  => create_goal_wrapped_message ()
     | _ => 
         match Control.case solvable_by_core_auto with
-        | Val _ => Message.of_string "The goal can be shown immediately, use ‘We conclude that (...).’."
+        | Val _ => of_string "The goal can be shown immediately, use ‘We conclude that (...).’."
         | Err exn => Control.zero (GoalHintError "No hint available for this goal.")
         end
     end.
@@ -165,10 +168,10 @@ Ltac2 print_goal_hint (g: constr option) :=
     match Control.case f with
     | Val mess => 
         match mess with
-        | (mess, _) => Message.print mess
+        | (mess, _) => print mess
         | _ => ()
         end
-    | Err exn => Message.print (Message.of_string "No hint available for this goal.")
+    | Err exn => print (of_string "No hint available for this goal.")
     end.
 
 (** * Help tactic

--- a/waterproof/tactics/sets_tactics/sets_automation_tactics.v
+++ b/waterproof/tactics/sets_tactics/sets_automation_tactics.v
@@ -24,7 +24,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 Require Import Reals.
 Require Import Sets.Ensembles.
 Require Import Sets.Classical_sets.

--- a/waterproof/tactics/simplify_chains.v
+++ b/waterproof/tactics/simplify_chains.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.definitions.inequality_chains.

--- a/waterproof/tactics/take.v
+++ b/waterproof/tactics/take.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.tactics.goal_wrappers.

--- a/waterproof/tactics/we_need_to_show.v
+++ b/waterproof/tactics/we_need_to_show.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.tactics.goal_wrappers.

--- a/waterproof/tactics/we_show_both_statements.v
+++ b/waterproof/tactics/we_show_both_statements.v
@@ -28,7 +28,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 
 From Waterproof Require Import auxiliary.

--- a/waterproof/test/reverse_engineer/auto_hintdb_arg.v
+++ b/waterproof/test/reverse_engineer/auto_hintdb_arg.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 (** Source code:
 
 * Notations.v

--- a/waterproof/test/reverse_engineer/auto_hintdb_arg.v
+++ b/waterproof/test/reverse_engineer/auto_hintdb_arg.v
@@ -30,8 +30,8 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
 
-
 Require Import Waterproof.message.
+Require Import Waterproof.test_auxiliary.
 (** Source code:
 
 * Notations.v
@@ -54,31 +54,33 @@ Ltac2 @ external auto : debug -> int option ->
     unit := "ltac2" "tac_auto".
 *)
 
-Ltac2 Notation "fake_auto" dbs(opt(seq("with", hintdb))) 
-    := default_db dbs.
+Ltac2 fake_default_db dbs := match dbs with
+| None => "No database provided"
+| Some dbs =>
+  match dbs with
+  | None => "Empty list provided"
+  | Some l => "List provided"
+  end
+end.
 
+Ltac2 Notation "fake_auto" dbs(opt(seq("with", hintdb))) 
+    := fake_default_db dbs.
+
+Goal True.
 (* To use the default, i.e. [core], 
     pass [Some ([])] to Std.auto
-    
-    Evidence: the following gives:
-    [Some ([])]
 *)
-Ltac2 Eval fake_auto.
+assert_string_equal (fake_auto) "No database provided".
 
 (* To use [with *], 
     i.e. all imported databases that Coq can find, 
     pass [None] to Std.auto
-    
-    Evidence: the following gives:
-    ['a list option = None]
 *)
-Ltac2 Eval fake_auto with *.
+assert_string_equal (fake_auto with *) "Empty list provided".
 
 (* To use [with somedb], 
     pass a list of idents
     (e.g. [Some ((@somedb)::[])]) to Std.auto.
-    
-    Evidence: the following gives:
-    [ident list option = Some ([@nocore])]
 *)
-Ltac2 Eval fake_auto with nocore.
+assert_string_equal (fake_auto with nocore) "List provided".
+Abort.

--- a/waterproof/test/string_auxiliary_test.v
+++ b/waterproof/test/string_auxiliary_test.v
@@ -22,7 +22,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Load string_auxiliary.
 Require Import Waterproof.test_auxiliary.

--- a/waterproof/test/string_auxiliary_test.v
+++ b/waterproof/test/string_auxiliary_test.v
@@ -32,8 +32,8 @@ Require Import Waterproof.test_auxiliary.
 *) (** *  Testcase for [replace_at_pos]
 *)
 
-Ltac2 Eval 
-    let result := (replace_at_pos "hollo" 1 (Char.of_int 101)) in
+Goal True.
+let result := (replace_at_pos "hollo" 1 (Char.of_int 101)) in
     assert_string_equal result "hello".
 
 
@@ -42,12 +42,10 @@ Ltac2 Eval
 *) (** *     Testcases for [concat_strings]
 *)
 
-Ltac2 Eval 
-    let result := (concat_strings "hello " "world") in
+let result := (concat_strings "hello " "world") in
     assert_string_equal result "hello world".
 
-Ltac2 Eval 
-    let result := (concat_strings "1" "2") in
+let result := (concat_strings "1" "2") in
     assert_string_equal result "12".
 
 (*
@@ -55,8 +53,7 @@ Ltac2 Eval
 *) (** *     Testcase for [copy_suffix_to_target]
 *)
 
-Ltac2 Eval
-    let result := (copy_suffix_to_target 12 1 
+let result := (copy_suffix_to_target 12 1 
                    "Hello world Unicorns!" "~_________~") in
     assert_string_equal result "~Unicorns!~".
 
@@ -64,12 +61,13 @@ Ltac2 Eval
 --------------------------------------------------------------------------------
 *) (**    Testcase for [add_to_ident_name]
 *)
-Ltac2 Eval Ident.equal @unicorn (add_to_ident_name @uni "corn").
+assert_is_true (Ident.equal @unicorn (add_to_ident_name @uni "corn")).
 
 (*
 --------------------------------------------------------------------------------
 *) (** * Testcases for [string_equal]
 *)
-Ltac2 Eval assert_is_true (string_equal "hello" "hello").
-Ltac2 Eval assert_is_false (string_equal "hello" "Hello").
-Ltac2 Eval assert_is_false (string_equal "hello" "hell").
+assert_is_true (string_equal "hello" "hello").
+assert_is_false (string_equal "hello" "Hello").
+assert_is_false (string_equal "hello" "hell").
+Abort.

--- a/waterproof/test/test_auxiliary_test.v
+++ b/waterproof/test/test_auxiliary_test.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Load test_auxiliary.
 
@@ -114,6 +116,13 @@ Proof.
     let t := constr:(forall x:nat, x < 0) in
     let result () := assert_goal_is t in
     assert_raises_error result.
+Abort.
+
+(** * Testcases for [assert_type_equal]
+*)
+
+Goal True.
+assert_type_equal constr:(5) constr:(nat).
 Abort.
 
 (*

--- a/waterproof/test/test_auxiliary_test.v
+++ b/waterproof/test/test_auxiliary_test.v
@@ -31,18 +31,19 @@ From Ltac2 Require Import Message.
 
 Load test_auxiliary.
 
+Goal True.
 (*
 --------------------------------------------------------------------------------
 *) (** *    Testcases for [assert_list_equal]
 *)
-Ltac2 Eval assert_list_equal (constr:(1)::constr:(2)::constr:(3)::[])
+assert_list_equal (constr:(1)::constr:(2)::constr:(3)::[])
                              (constr:(1)::constr:(2)::constr:(3)::[]).
 
-Ltac2 Eval assert_list_equal [] [].                             
+assert_list_equal [] [].                             
 
-Ltac2 Eval assert_raises_error (fun () =>
+assert_raises_error (fun () =>
 assert_list_equal (constr:(1)::constr:(3)::[]) (constr:(2)::constr:(3)::[]) ).
-
+Abort.
 (*
 --------------------------------------------------------------------------------
 *)(** * Testcase for [assert_hyp_exists]
@@ -68,29 +69,29 @@ Goal forall n: nat, n = 1 -> n = 1.
     assert_raises_error (fun () => assert_hyp_has_type @n constr:(bool)).
 Abort.
 
-
+Goal True.
 (*
 --------------------------------------------------------------------------------
 *) (** *    Testcases for [assert_constr_is_true]
 *)
-Ltac2 Eval assert_constr_is_true constr:(true).
-Ltac2 Eval assert_raises_error 
+assert_constr_is_true constr:(true).
+assert_raises_error 
     (fun () => assert_constr_is_true constr:(false)).
-    Ltac2 Eval assert_raises_error 
+assert_raises_error 
     (fun () => assert_constr_is_true constr:(1)).
 
 (*
 --------------------------------------------------------------------------------
 *) (** *    Testcases for [assert_is_true] and [assert_is_false].
 *)
-Ltac2 Eval assert_is_true (true).
-Ltac2 Eval assert_raises_error 
+assert_is_true (true).
+assert_raises_error 
     (fun () => assert_is_true false).
 
-Ltac2 Eval assert_is_false (false).
-Ltac2 Eval assert_raises_error 
+assert_is_false (false).
+assert_raises_error 
     (fun () => assert_is_false true).
-
+Abort.
 (*
 --------------------------------------------------------------------------------
 *) (** * Testcases for [assert_goal_is]
@@ -119,8 +120,9 @@ Abort.
 --------------------------------------------------------------------------------
 *) (** * Testcases for [assert_constr_equal]
 *)
-
-Ltac2 Eval assert_constr_equal constr:(1 < 2) constr:(1 < 2).
-Ltac2 Eval let result () := assert_constr_equal constr:(1 < 2) 
+Goal True.
+assert_constr_equal constr:(1 < 2) constr:(1 < 2).
+let result () := assert_constr_equal constr:(1 < 2) 
                                                 constr:(1 > 2) in
     assert_raises_error result.
+Abort.

--- a/waterproof/test/test_inequality_chains.v
+++ b/waterproof/test/test_inequality_chains.v
@@ -24,6 +24,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 (* Tests for (in)equality chains *)
 
+From Ltac2 Require Import Ltac2.
+Require Import Waterproof.test_auxiliary.
+
 Load inequality_chains.
 
 (* Test 0: check if notations work. *)
@@ -67,14 +70,16 @@ Goal (& 1 ≥ 2 > 3 = 4). Abort.
 Check (& 1 < 2 = 3 > 4). (* Does type check, but the kernel has not found correct instance for '>' *)
 Fail Goal (& 1 < 2 = 3 > 4). (* Esoteric error. *)
 (* Check for correctness global, weak global and total stamements. *)
-Eval cbn in (& 1 = 2 = 3 = 4). (* Expected: (1 = 2 /\ 2 = 3) /\ 3 = 4 *)
+Goal True.
+assert_constr_equal (eval cbn in (& 1 = 2 = 3 = 4)) constr:((1 = 2 /\ 2 = 3) /\ 3 = 4).
 (*Eval cbn in (global_statement (& 1 = 2 = 3 = 4)). (* Expected: 1 = 4 , :( *) (* Untestable *)*)
-Eval cbn in (& 1 < 2 = 3 < 4). (* Expected: (1 < 2 /\ 2 = 3) /\ 3 < 4 *)
+assert_constr_equal (eval cbn in (& 1 < 2 = 3 < 4)) constr:((1 < 2 /\ 2 = 3) /\ 3 < 4).
 (*Eval cbn in (global_statement (1 &< 2 &< 3 &= 4)). (* Expected: 1 < 4 *) (* Untestable *)*)
 (*Eval cbn in (weak_global_statement (1 &< 2 &< 3 &= 4)). (* Expected: 1 <= 4*) (* Untestable *)*)
-Eval cbn in (& 1 > 2 > 3 = 4). (* Expected: (1 > 2 /\ 2 > 3) /\ 3 = 4 *)
+assert_constr_equal (eval cbn in (& 1 > 2 > 3 = 4)) constr:((1 > 2 /\ 2 > 3) /\ 3 = 4). (* Expected: (1 > 2 /\ 2 > 3) /\ 3 = 4 *)
 (*Eval cbn in (global_statement (1 &> 2 &> 3 &= 4)). (* Expected: 1 > 4 *) (* Untestable *)*)
 (*Eval cbn in (weak_global_statement (1 &> 2 &> 3 &= 4)). (* Expected: 1 >= 4 *) (* Untestable *)*)
+Abort.
 
 (* Usage in hypotheses *)
 Goal (& 1 < 2 < 3) -> (& 4 = 100 = 100) -> (1 < 3).

--- a/waterproof/test/test_inequality_chains.v
+++ b/waterproof/test/test_inequality_chains.v
@@ -57,12 +57,12 @@ Abort.
 
 (** More tests *)
 (* Valid (though incorrect) inputs *)
-Check (& 1 = 2 = 2).
-Check (& 1 = 2 = 3 = 4).
-Check (& 1 = 2 < 3 = 4).
-Check (& 1 = 2 < 3 ≤ 4).
-Check (& 1 = 2 > 3 = 4).
-Check (& 1 ≥ 2 > 3 = 4).
+Goal (& 1 = 2 = 2). Abort.
+Goal (& 1 = 2 = 3 = 4). Abort.
+Goal (& 1 = 2 < 3 = 4). Abort.
+Goal (& 1 = 2 < 3 ≤ 4). Abort.
+Goal (& 1 = 2 > 3 = 4). Abort.
+Goal (& 1 ≥ 2 > 3 = 4). Abort.
 (* Invalid input: combining < and > in one chain *)
 Check (& 1 < 2 = 3 > 4). (* Does type check, but the kernel has not found correct instance for '>' *)
 Fail Goal (& 1 < 2 = 3 > 4). (* Esoteric error. *)

--- a/waterproof/test/test_inequality_chains.v
+++ b/waterproof/test/test_inequality_chains.v
@@ -25,6 +25,7 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 (* Tests for (in)equality chains *)
 
 From Ltac2 Require Import Ltac2.
+Require Import Waterproof.auxiliary.
 Require Import Waterproof.test_auxiliary.
 
 Load inequality_chains.
@@ -67,12 +68,15 @@ Goal (& 1 = 2 < 3 ≤ 4). Abort.
 Goal (& 1 = 2 > 3 = 4). Abort.
 Goal (& 1 ≥ 2 > 3 = 4). Abort.
 (* Invalid input: combining < and > in one chain *)
-Check (& 1 < 2 = 3 > 4). (* Does type check, but the kernel has not found correct instance for '>' *)
+Goal True.
+Fail pose (Aux.type_of (& 1 < 2 = 3 > 4)).
+epose (Aux.type_of (& 1 < 2 = 3 > 4)). (* Does type check, evars are added ... *)
+Abort.
 Fail Goal (& 1 < 2 = 3 > 4). (* Esoteric error. *)
 (* Check for correctness global, weak global and total stamements. *)
 Goal True.
 assert_constr_equal (eval cbn in (& 1 = 2 = 3 = 4)) constr:((1 = 2 /\ 2 = 3) /\ 3 = 4).
-(*Eval cbn in (global_statement (& 1 = 2 = 3 = 4)). (* Expected: 1 = 4 , :( *) (* Untestable *)*)
+(* Eval cbn in (global_statement (& 1 = 2 = 3 = 4)).*) (* Expected: 1 = 4 , :( *) (* Untestable *)
 assert_constr_equal (eval cbn in (& 1 < 2 = 3 < 4)) constr:((1 < 2 /\ 2 = 3) /\ 3 < 4).
 (*Eval cbn in (global_statement (1 &< 2 &< 3 &= 4)). (* Expected: 1 < 4 *) (* Untestable *)*)
 (*Eval cbn in (weak_global_statement (1 &< 2 &< 3 &= 4)). (* Expected: 1 <= 4*) (* Untestable *)*)

--- a/waterproof/test/test_load_database.v
+++ b/waterproof/test/test_load_database.v
@@ -43,13 +43,9 @@ Require Import Waterproof.load_database.DisableWildcard.
 
 Local Open Scope R_scope.
 
-
-Ltac2 Eval print (of_string "Initial database selection is:").
 (* Note: [core] is always *implicitly* included. *)
 
 Require Import load_database.All.
-Ltac2 Eval global_database_selection. 
-
 
 (*
 --------------------------------------------------------------------------------
@@ -66,17 +62,12 @@ Qed.
 
 Ltac2 Set global_database_selection as old_selection := [].
 
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
-
 (** * Test 1b
     Lemma that should be NOT proveable with [nocore].
 *)
 Lemma load_db_test_1b: forall x y:R, (x + y)^2 = x^2 + y^2 + 2*x*y.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
-
 Abort.
 
 (*
@@ -87,10 +78,6 @@ Abort.
 (* loding the specified database*)
 Require Import load_database.Multiplication.
 Require Import Waterproof.set_search_depth.To_3.
-
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
 
 (** * Test 2a
     Test for sufficiency. 
@@ -120,10 +107,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 Require Import load_database.PlusMinus.
 Require Import Waterproof.set_search_depth.To_3.
 
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
-
 (** * Test 2c
     Test for necessity, which passes if an error is raised, i.e. when
     the specified database is missing. 
@@ -131,7 +114,6 @@ Ltac2 Eval global_database_selection.
 Lemma load_db_test_2c: forall x y:R, (x + y)*x = x*x + x*y.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
-
 Abort.
 
 
@@ -148,10 +130,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 (* loding the specified database*)
 Require Import load_database.PlusMinus.
 Require Import Waterproof.set_search_depth.To_3.
-
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
 
 (** * Test 3a
     Test for sufficiency. 
@@ -171,7 +149,6 @@ Qed.
 Lemma load_db_test_3b: forall x y:R, x*y = y *x.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
-
 Abort.
 
 (* reset the selection of databases*)
@@ -181,10 +158,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 Require Import load_database.Multiplication.
 Require Import Waterproof.set_search_depth.To_3.
 
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
-
 (** * Test 3c
     Test for necessity, which passes if an error is raised, i.e. when
     the specified database is missing. 
@@ -192,7 +165,6 @@ Ltac2 Eval global_database_selection.
 Lemma load_db_test_3c: forall x y:R, x + x + y = x + y + x.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
-
 Abort.
 
 (* reset the selection of databases*)
@@ -207,10 +179,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 (* loding the specified database*)
 Require Import load_database.ZeroOne.
 Require Import Waterproof.set_search_depth.To_3.
-
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
 
 (** * Test 4a
     Test for sufficiency. 
@@ -240,10 +208,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 Require Import load_database.Multiplication.
 Require Import Waterproof.set_search_depth.To_3.
 
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
-
 (** * Test 4c
     Test for necessity, which passes if an error is raised, i.e. when
     the specified database is missing. 
@@ -251,7 +215,6 @@ Ltac2 Eval global_database_selection.
 Lemma load_db_test_4c: forall x y:R, x*1 + 1 + 0 = x +1.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
-
 Abort.
 
 (* reset the selection of databases*)
@@ -260,8 +223,6 @@ Ltac2 Set global_database_selection as old_selection := [].
 
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBMultiplication)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 
 (** * Test 12
     Same as test 2, but now the WRONG database is loaded.
@@ -275,8 +236,6 @@ Abort.
 Ltac2 Set global_database_selection as old_selection :=[].
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBReals)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 
 (** * Test 13
     Same as test 2, but now the REQUIRED database is loaded.
@@ -289,9 +248,6 @@ Qed.
 (*Empty the database*)
 Ltac2 Set global_database_selection as old_selection :=[].
 Require Import load_database.All.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
-
 
 (** * Test 14
     Similarly, this can be solved with the WaterproofDBGeneral, 
@@ -328,16 +284,12 @@ Proof.
     Ltac2 Set global_database_selection as old_selection :=[].
     Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBZeroOne)::old_selection.
-    Ltac2 Eval print (of_string "Current database selection is:").
-    Ltac2 Eval global_database_selection.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
 Abort.
 
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBMultiplication)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 Ltac2 Set global_search_depth := 1.
 
 (** * Test 17
@@ -372,8 +324,6 @@ Ltac2 Set global_database_selection as old_selection :=
     This test should not be solved, since it has all 
     databases except the required one.
 *)
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 Goal forall a:R, ln(exp a) = a.
     let result () := waterprove (Control.goal ()) [] false in
     assert_raises_error result.
@@ -382,8 +332,6 @@ Abort.
 Ltac2 Set global_database_selection as old_selection :=[].
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBExponential)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 (** * Test 20
     This test should work just fine now.
 *)
@@ -402,8 +350,6 @@ Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBSquareRoot)::old_selection.
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBExponential)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 
 (** * Test 21
     This test should not be solved, since it has all 
@@ -417,8 +363,6 @@ Abort.
 Ltac2 Set global_database_selection as old_selection :=[].
 Ltac2 Set global_database_selection as old_selection :=
     (WaterproofDBAbsoluteValue)::old_selection.
-Ltac2 Eval print (of_string "Current database selection is:").
-Ltac2 Eval global_database_selection.
 
 (** * Test 22
     This test should work just fine now.

--- a/waterproof/test/test_load_database.v
+++ b/waterproof/test/test_load_database.v
@@ -31,7 +31,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Reals.
 Require Import Waterproof.test_auxiliary.

--- a/waterproof/test/test_message.v
+++ b/waterproof/test/test_message.v
@@ -1,0 +1,62 @@
+(** * Testcases for [inequality_chains.v]
+Authors: 
+    - Jim Portegies
+Creation date: 4 Mar 2023
+
+Testcases for messages.v
+--------------------------------------------------------------------------------
+
+This file is part of Waterproof-lib.
+
+Waterproof-lib is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Waterproof-lib is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
+*)
+
+(* Tests for messages.v *)
+
+From Ltac2 Require Import Ltac2.
+Require Import Waterproof.test_auxiliary.
+
+Load message.
+
+(** Uncomment the next line to increase the test verbosity. *)
+(* Ltac2 Set test_verbosity := fun () => 1. *)
+
+Ltac2 store_verbosity := verbosity.
+
+(** set below to true to actually do the tests. *)
+Ltac2 verbose := fun () => if (ge (test_verbosity ()) 1) then true else false.
+
+Ltac2 Set verbosity := fun () => if (verbose ())
+    then 2 else -1.
+
+(** Should print something if test_verbosity is larger than or equal to 1. *)
+Goal True.
+print (of_string "This string should be printed if test_verbosity is larger than or equal to 1.").
+Abort.
+
+Goal True.
+Ltac2 Set verbosity := fun () => -1.
+print (of_string "This should not be printed").
+Abort.
+
+(** Uncomment the following line to set the verbosity higher
+    and print more messages. *)
+
+Ltac2 Set verbosity := fun () => 1.
+
+(** Should print a message: *)
+
+
+
+Ltac2 Set verbosity := store_verbosity.

--- a/waterproof/test/test_set_definitions.v
+++ b/waterproof/test/test_set_definitions.v
@@ -23,7 +23,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
-
 Require Import Waterproof.definitions.set_definitions.
 Require Import Waterproof.notations.notations.
 Require Import Reals.
@@ -35,9 +34,9 @@ Local Parameter P : R -> Prop.
 Definition A := as_subset R P.
 
 Local Parameter x : R.
-Check (x : A).
-Check (is_lub A).
-Check (x : [0,1]).
+Definition type_check_1 : Prop := (x : A).
+Definition type_check_2 : (R -> Prop) := is_lub A.
+Definition type_check_3 : Prop :=  (x : [0,1]).
 
 Goal is_upper_bound [0,1] 1.
 Proof.

--- a/waterproof/test/test_set_intuition.v
+++ b/waterproof/test/test_set_intuition.v
@@ -28,7 +28,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.selected_databases.

--- a/waterproof/test/test_set_search_depth.v
+++ b/waterproof/test/test_set_search_depth.v
@@ -29,7 +29,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Reals.
 Require Import Waterproof.test_auxiliary.

--- a/waterproof/test/test_set_search_depth.v
+++ b/waterproof/test/test_set_search_depth.v
@@ -36,11 +36,7 @@ Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.selected_databases.
 Require Import Waterproof.waterprove.waterprove.
 
-Ltac2 Eval print (of_string "Initial search depth is:").
-Ltac2 Eval global_search_depth. 
 Require Import Waterproof.set_search_depth.To_1.
-Ltac2 Eval print (of_string "Current search depth is:").
-Ltac2 Eval global_search_depth. 
 
 Open Scope R_scope.
 
@@ -73,8 +69,6 @@ Abort.
 *)
 
 Require Import Waterproof.set_search_depth.To_2.
-Ltac2 Eval print (of_string "Current search depth is:").
-Ltac2 Eval global_search_depth. 
 
 (** * Test 3
     Same as test 2, but now search depth should be sufficient.

--- a/waterproof/test/test_tactics/assume_test.v
+++ b/waterproof/test/test_tactics/assume_test.v
@@ -23,7 +23,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Load assume.

--- a/waterproof/test/test_tactics/goal_to_hint_test.v
+++ b/waterproof/test/test_tactics/goal_to_hint_test.v
@@ -26,9 +26,19 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+From Ltac2 Require Import Int.
+
+Require Import Waterproof.test_auxiliary.
+
+
+Require Import Waterproof.message.
 
 Load goal_to_hint.
+
+Ltac2 store_verbosity := verbosity.
+
+Ltac2 Set verbosity := fun () => if (le (test_verbosity ()) 0) 
+    then -1 else (store_verbosity ()).
 
 (** * Test 1
     Should print a hint for a ∀-goal twice.
@@ -156,3 +166,4 @@ print(of_string "
     ").
 Abort.
 
+Ltac2 Set verbosity := store_verbosity.

--- a/waterproof/test/test_tactics/goal_to_hint_test.v
+++ b/waterproof/test/test_tactics/goal_to_hint_test.v
@@ -37,10 +37,8 @@ Goal forall x:nat, x = x.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
-
-    (* Print some whitelines*)
-    Ltac2 Eval print (of_string "
-
+    print(of_string "
+    
     ").
 Abort.
 
@@ -52,10 +50,8 @@ Goal 0=0 -> 0=0.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
     
-    (* Print some whitelines*)
-    Ltac2 Eval print (of_string "
-
     ").
 Abort.
 
@@ -66,10 +62,8 @@ Goal nat -> nat.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
     
-    (* Print some whitelines*)
-    Ltac2 Eval print (of_string "
-
     ").
 Abort.
 
@@ -81,6 +75,9 @@ Goal exists x:nat, x = 1.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
+    
+    ").
 Abort.
 
 
@@ -93,6 +90,9 @@ Goal forall n, n + 0 = n.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
+    
+    ").
 Abort.
 
 (** * Test 5
@@ -102,6 +102,9 @@ Goal not (0 = 1).
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
+    
+    ").
 Abort.
 
 (** * Test 6
@@ -111,6 +114,9 @@ Goal False.
     print (goal_to_hint (Control.goal ())).
     (* Should print exactly the same:*)
     Help.
+    print(of_string "
+    
+    ").
 Abort.
 
 
@@ -118,23 +124,35 @@ Abort.
 Goal (0 = 0) /\ (0 = 1).
 Proof.
   Help.
+  print(of_string "
+    
+").
 Abort.
 
 (** * Test 8, should print hint for disjunction. *)
 Goal (0 = 0) \/ (0 = 1).
 Proof.
   Help.
+print(of_string "
+    
+    ").
 Abort.
 
 (** * Test 9, should print hint for trivial statement. *)
 Goal (0 = 0).
 Proof.
   Help.
+print(of_string "
+    
+    ").
 Abort.
 
 (** * Test 10, should not print hint for non-trivial statement. *)
 Goal (0 = 1).
 Proof.
   Help.
+print(of_string "
+    
+    ").
 Abort.
 

--- a/waterproof/test/test_tactics/such_that_test.v
+++ b/waterproof/test/test_tactics/such_that_test.v
@@ -23,7 +23,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.tactics.take.

--- a/waterproof/test/test_tactics/take_test.v
+++ b/waterproof/test/test_tactics/take_test.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Load take.

--- a/waterproof/test/test_tactics/test_because.v
+++ b/waterproof/test/test_tactics/test_because.v
@@ -94,7 +94,6 @@ Goal forall n : nat, ( ( (n = n) /\ (n + 1 = n + 1) ) -> (n + 1 = n + 1)).
     intro i.
     Fail Because (i) both (n = n) (i) and (n + 1 = n + 1) hold.
     Because (i) both (n = n) and (n + 1 = n + 1) hold.
-    Check i.
 Abort.
 
 (** Test 8 : Tests if the 'Because ... either ... or ...' tactic does not 
@@ -104,5 +103,4 @@ Goal forall n : nat, ( ( (n = n) \/ (n + 1 = n + 1) ) -> (n + 1 = n + 1)).
     intro i.
     Fail Because (i) either (n = n) (i) or (n + 1 = n + 1) holds.
     Because (i) either (n = n) or (n + 1 = n + 1) holds.
-    Check i.
 Abort.

--- a/waterproof/test/test_tactics/test_choose_such_that.v
+++ b/waterproof/test/test_tactics/test_choose_such_that.v
@@ -71,7 +71,6 @@ Goal (exists n : nat, n + 1 = n)%nat -> False.
 Proof.
   intro i.
   Obtain n according to (i), so for n : nat it holds that (n + 1 = n)%nat.
-  Check (i).
 Abort.
 
 (** Test 5: tactic also works for destructing sig types *)

--- a/waterproof/test/test_tactics/test_forward_reasoning/it_holds_that_test.v
+++ b/waterproof/test/test_tactics/test_forward_reasoning/it_holds_that_test.v
@@ -35,8 +35,6 @@ Require Import Waterproof.selected_databases.
 Require Import Waterproof.load_database.All.
 Require Import Waterproof.load_database.DisableWildcard.
 
-Ltac2 Eval global_database_selection.
-
 (* lra only works in the [R_scope] *)
 Local Open Scope R_scope.
 Lemma zero_lt_one: 0 < 1.
@@ -56,9 +54,6 @@ Qed.
 
 (* -------------------------------------------------------------------------- *)
 (** * Testcases for [By ... it holds that ... : ...] *)
-Ltac2 Eval (print (of_string "
-
-Testcases for [By ... it holds that ... : ...]:" )).
 
 (** * Test 1
     Base case: intoduce a sublemma with a lemma that proves it
@@ -102,10 +97,6 @@ Abort.
 
 (* -------------------------------------------------------------------------- *)
 (** * Testcases for [It holds that ... : ...] *)
-Ltac2 Eval (print (of_string "
-
-Testcases for [It holds that ... : ...]:" )).
-
 
 (** * Test 1
     Base case: intoduce a sublemma that can be proven immediately.
@@ -137,9 +128,6 @@ Open Scope nat_scope.
 Inductive even : nat -> Prop :=
     even0 : even 0
   | evenS : forall x:nat, even x -> even (S (S x)).
-
-
-Ltac2 Eval global_database_selection.
 
 Lemma it_holds_example: forall x:nat, x > 1 /\ x < 3 -> even x.
 Proof.

--- a/waterproof/test/test_tactics/test_forward_reasoning/it_holds_that_test.v
+++ b/waterproof/test/test_tactics/test_forward_reasoning/it_holds_that_test.v
@@ -23,7 +23,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Reals.
 Require Import Waterproof.set_search_depth.To_5.

--- a/waterproof/test/test_tactics/test_forward_reasoning/it_suffices_to_show_test.v
+++ b/waterproof/test/test_tactics/test_forward_reasoning/it_suffices_to_show_test.v
@@ -22,7 +22,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.set_search_depth.To_5.
 Require Import Waterproof.set_intuition.Disabled.

--- a/waterproof/test/test_tactics/test_forward_reasoning/we_conclude_that_test.v
+++ b/waterproof/test/test_tactics/test_forward_reasoning/we_conclude_that_test.v
@@ -44,9 +44,6 @@ Qed.
 
 (* -------------------------------------------------------------------------- *)
 (** * Testcases for [We conclude that ... ] *)
-Ltac2 Eval (print (of_string "
-
-Testcases for [We conclude that ...]:" )).
 
 (** * Test 1
     Base case: should easily be possible to finish the goal.
@@ -110,9 +107,6 @@ Qed.
 
 (* -------------------------------------------------------------------------- *)
 (** * Testcases for [By ... we conclude that ... ] *)
-Ltac2 Eval (print (of_string "
-
-Testcases for [By ... we conclude that ...]:" )).
 
 (** * Test 1
     Base case: should easily be possible to finish the goal,

--- a/waterproof/test/test_tactics/test_forward_reasoning/we_conclude_that_test.v
+++ b/waterproof/test/test_tactics/test_forward_reasoning/we_conclude_that_test.v
@@ -22,7 +22,10 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+From Ltac2 Require Import Int.
+
+
+Require Import Waterproof.message.
 Require Import Reals.
 Require Import micromega.Lra.
 
@@ -34,6 +37,10 @@ Require Import Waterproof.load_database.RealsAndIntegers.
 Load we_conclude_that.
 Require Import Waterproof.load_database.DisableWildcard.
 
+Ltac2 store_verbosity := verbosity.
+
+Ltac2 Set verbosity := fun () => if (le (test_verbosity ()) 0) 
+    then -1 else (store_verbosity ()).
 
 (* lra only works in the [R_scope] *)
 Open Scope R_scope.
@@ -68,7 +75,7 @@ Abort.
 *)
 Lemma test_we_conclude_3: 2 = 2.
 Proof.
-    Ltac2 Eval (print (of_string "Should raise warning:")).
+    print (of_string "Should raise warning:").
     We conclude that (1+1 = 2).
 Qed.
 
@@ -150,7 +157,7 @@ Qed.*)
 *)
 Lemma test_by_we_conclude_3: 2 = 1 + 1.
 Proof.
-    Ltac2 Eval (print (of_string "Should raise warning:")).
+    print (of_string "Should raise warning:").
     By zero_lt_one we conclude that (2 = 2).
 Qed.
 
@@ -275,7 +282,4 @@ intro p.
 Fail We conclude that (& x = y = z). (* Expected: unable to find proof (y = z) *)
 Abort.
 
-
-
-
-
+Ltac2 Set verbosity := store_verbosity.

--- a/waterproof/test/test_tactics/test_simplify_chains.v
+++ b/waterproof/test/test_tactics/test_simplify_chains.v
@@ -25,7 +25,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Require Import Waterproof.definitions.inequality_chains.

--- a/waterproof/test/test_tactics/we_need_to_show_test.v
+++ b/waterproof/test/test_tactics/we_need_to_show_test.v
@@ -27,7 +27,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.test_auxiliary.
 Load we_need_to_show.

--- a/waterproof/test_auxiliary.v
+++ b/waterproof/test_auxiliary.v
@@ -25,13 +25,16 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
+From Ltac2 Require Import Int.
 
 Require Import Waterproof.string_auxiliary.
 Require Import Waterproof.auxiliary.
 
-(* TODO: make this an integer *)
-Ltac2 mutable test_verbosity := false.
+(** * Introduce global test verbosity. *)
+Ltac2 mutable test_verbosity () := 0.
 
 Ltac2 Type exn ::= [ TestFailedError(message) ].
 
@@ -44,8 +47,17 @@ Ltac2 fail_test (msg:message) :=
         [auxiliary.v] AND [test_auxiliary.v]. *)
 Definition type_of_test_aux {T : Type} (x : T) := T.
 
+(** * print_success
+    A function that prints a message in case
+    a test is passed. The function only prints 
+    if the global test_verbosity is larger than or equal 
+    than 1.
+
+    Arguments:
+        - [msg : message] The message to print on success.
+*)
 Ltac2 print_success (msg : message) := 
-  match test_verbosity with 
+  match (ge (test_verbosity ()) 1) with 
   |  false => ()
   |  _ => print msg
   end.

--- a/waterproof/theory/analysis/limsup_liminf_bolzano.v
+++ b/waterproof/theory/analysis/limsup_liminf_bolzano.v
@@ -185,6 +185,7 @@ Proof.
     We need to show that (is_index_seq m ∧ Un_cv (fun k ↦ a(m(k)), L)).
     We show both statements.
     - We need to show that (is_index_seq m).
+      It suffices to show that (is_index_seq n).
       By (v) we conclude that (is_index_seq n).
     - We need to show that (Un_cv (fun k ↦ a(n(k)), L)).
       (** TODO: an equivalent to "apply with" would be nice here *)
@@ -224,6 +225,7 @@ Proof.
       (is_index_seq n0 ∧ Un_cv (fun (k : ℕ) ↦ a (n0 k)) (proj1_sig (_,_,lim_sup_bdd a (i) (iii)))).
     Choose n := n0.
     Choose l := (proj1_sig (_,_,lim_sup_bdd a (i) (iii))).
+    It suffices to show that (is_index_seq n ∧ Un_cv (fun k ↦ a(n(k)), proj1_sig (_,_,lim_sup_bdd a (i) (iii)))).
     We conclude that (is_index_seq n ∧ Un_cv (fun k ↦ a(n(k)), proj1_sig (_,_,lim_sup_bdd a (i) (iii)))).
 Qed.
 

--- a/waterproof/theory/analysis/sequences.v
+++ b/waterproof/theory/analysis/sequences.v
@@ -85,7 +85,6 @@ Lemma convergence_equivalence : converges_to = Un_cv.
 Proof.
     trivial.
 Qed.
-Locate converges_to.
 
 (** ## Preparation for a simple limit*)
 Lemma archimed_mod :
@@ -101,7 +100,7 @@ Proof.
         We conclude that (1 > 0).
       }
       It holds that (x <= INR 0).
-      It follows that (INR 1 > x).
+      It follows that (n > x).
     - Case (0 < x).
       By archimed it holds that (IZR( up x) > x ∧ IZR( up x ) - x ≤ 1).
       It holds that (IZR( up x ) > x).

--- a/waterproof/theory/analysis/subsequences.v
+++ b/waterproof/theory/analysis/subsequences.v
@@ -128,7 +128,7 @@ Proof.
         (for all m N : ℕ, (g m N ≥ N)%nat).
       Take m, M : nat.
       By (ii) it holds that ((M ≤ g m M)%nat ∧ P m (a (g m M))).
-      We conclude that (M <= g m M)%nat.
+      We conclude that (g m M >= M)%nat.
     - We need to show that (for all k : ℕ, P k (a (n k))).
       We need to show that (for all k : ℕ, P k (a ((create_seq g) k))).
       Fail By subseq_sat_rel it suffices to show that (for all m N : ℕ, P m (a (g m N))). (*TODO: fix*)

--- a/waterproof/theory/analysis/subsequences_metric.v
+++ b/waterproof/theory/analysis/subsequences_metric.v
@@ -122,9 +122,6 @@ Proof.
     Expand the definition of is_increasing. (*TODO: the layout of is_increasing is confusing*)
     That is, write the goal as 
       ((for all k : ℕ, (g k ≤ g (k + 1))%nat) ⇨ for all k l : ℕ, (k ≤ l ⇨ g k ≤ g l)%nat ).
-    Check family.
-    Locate family.
-    Check ℕ.
     Assume that (∀ k : ℕ, (g k) ≤ (g (k + 1)))%nat.
     Take k : ℕ.
     We use induction on l.

--- a/waterproof/theory/analysis/sup_and_inf_new_definitions.v
+++ b/waterproof/theory/analysis/sup_and_inf_new_definitions.v
@@ -33,11 +33,7 @@ Require Import Waterproof.set_search_depth.To_5.
 Require Import Waterproof.set_intuition.Disabled.
 Require Import Waterproof.load_database.DisableWildcard.
 
-
-Ltac2 Eval global_database_selection.
-
 Open Scope R_scope.
-
 
 Notation is_bounded_above := bound.
 Notation is_sup := is_lub.
@@ -251,7 +247,7 @@ Proof.
     Obtain m according to (i), so for m : R it holds that (is_lower_bound A m).
     
     Choose M := (-m).
-    By low_bd_set_to_upp_bd_set_opp we conclude that (is_upper_bound (set_opp A) (-m)).
+    By low_bd_set_to_upp_bd_set_opp we conclude that (is_upper_bound (set_opp A) (M)).
 Qed.
 
 

--- a/waterproof/waterprove/automation_subroutine.v
+++ b/waterproof/waterprove/automation_subroutine.v
@@ -30,7 +30,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.selected_databases.
 

--- a/waterproof/waterprove/manipulate_negation.v
+++ b/waterproof/waterprove/manipulate_negation.v
@@ -33,7 +33,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 
 From Ltac2 Require Import Ltac2.
 From Ltac2 Require Option.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.auxiliary.
 Require Import Waterproof.selected_databases.

--- a/waterproof/waterprove/waterprove.v
+++ b/waterproof/waterprove/waterprove.v
@@ -30,7 +30,9 @@ along with Waterproof-lib.  If not, see <https://www.gnu.org/licenses/>.
 *)
 
 From Ltac2 Require Import Ltac2.
-From Ltac2 Require Import Message.
+
+
+Require Import Waterproof.message.
 
 Require Import Waterproof.definitions.inequality_chains.
 Require Import Waterproof.selected_databases.


### PR DESCRIPTION
Introduce a global `test_verbosity` and a `verbosity` that handle verbosity in output of tests and of normal statements respectively. As a consequence, the standard compilation process should now be silent: if tests pass, there is no output.