### PR TITLE
Added tactic for unfolding that prints a message instead of throwing an errror.

### DIFF
--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -92,3 +92,37 @@ Goal False.
 Proof.
   Fail Expand the definition of foo2 in 0.
 Abort.
+
+
+(** Check unfolding method that does not throw an error.
+  Meant for internal use by custom Waterproof editor. *)
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_foo (Some "foo2") statement.
+
+(* Test 9: unfold term in statement. *)
+Goal False.
+Proof.
+  _internal_ Expand the definition of foo2 in foo.
+Abort.
+
+(* Test 10: unfold term in statement matching goal, and prints a message suggesting 
+    to replace line with 'We need to show that ...'. *)
+Goal foo = 1.
+Proof.
+  _internal_ Expand the definition of foo2 in (foo = 1).
+Abort.
+
+(* Test 11: unfold term in statement matching a hypothesis and prints a message suggesting 
+    to replace line with 'It holds that ...'. *)
+Goal (foo = 0) -> (foo = 2) -> (foo = 1).
+Proof.
+  intros.
+  _internal_ Expand the definition of foo2 in (foo = 0).
+  _internal_ Expand the definition of foo2 in (foo = 2).
+Abort.
+
+(* Test 12: fails to unfold term in statment without term. *)
+Goal False.
+Proof.
+   _internal_ Expand the definition of foo2 in 0.
+Abort.

--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -91,7 +91,8 @@ Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at l
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
   unfold_in_statement unfold_acc_point (Some "accumulation point") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_acc_point (Some "accumulation point") statement.
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
 
@@ -101,6 +102,8 @@ Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_po
 
 Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
   unfold_in_statement unfold_isol_point (Some "isolated point") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_isol_point (Some "isolated point") statement.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68).
 
@@ -110,6 +113,8 @@ Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_poi
 
 Ltac2 Notation "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
   unfold_in_statement unfold_lim_in_point (Some "limit") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_lim_in_point (Some "limit") statement.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 68).
@@ -120,6 +125,8 @@ Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in 
 
 Ltac2 Notation "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
   unfold_in_statement unfold_is_cont (Some "continuous") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_cont (Some "continuous") statement.
 
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -50,6 +50,8 @@ Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at l
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
   unfold_in_statement unfold_acc_point (Some "accumulation point") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_acc_point (Some "accumulation point") statement.
 
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
@@ -60,6 +62,8 @@ Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_po
 
 Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
   unfold_in_statement unfold_isol_point (Some "isolated point") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_isol_point (Some "isolated point") statement.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68).
 
@@ -69,6 +73,8 @@ Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_poi
 
 Ltac2 Notation "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
   unfold_in_statement unfold_lim_in_point (Some "limit") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_lim_in_point (Some "limit") statement.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 68).
@@ -79,6 +85,8 @@ Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in 
 
 Ltac2 Notation "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
   unfold_in_statement unfold_is_cont (Some "continuous") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_cont (Some "continuous") statement.
 
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -48,9 +48,13 @@ Local Ltac2 unfold_open_ball (statement : constr) := eval unfold open_ball, pred
 
 Ltac2 Notation "Expand" "the" "definition" "of" "B" "in" statement(constr) := 
   unfold_in_statement unfold_open_ball (Some "B") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "B" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_open_ball (Some "B") statement.
 
 Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" "in" statement(constr) := 
   unfold_in_statement unfold_open_ball (Some "open ball ") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_open_ball (Some "open ball ") statement.
 
 Notation "a 'is' 'an' '_interior' 'point_' 'of' A" := (is_interior_point a A) (at level 68).
 
@@ -60,6 +64,8 @@ Local Ltac2 unfold_is_interior_point (statement : constr) := eval unfold is_inte
 
 Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" "in" statement(constr) := 
   unfold_in_statement unfold_is_interior_point (Some "interior point") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_interior_point (Some "interior point") statement.
 
 Notation "A 'is' '_open_'" := (is_open A) (at level 68).
 
@@ -69,7 +75,8 @@ Local Ltac2 unfold_is_open (statement : constr) := eval unfold is_open in $state
 
 Ltac2 Notation "Expand" "the" "definition" "of" "open" "in" statement(constr) := 
   unfold_in_statement unfold_is_open (Some "open") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_open (Some "open") statement.
 
 Notation "'ℝ\' A" := (complement A) (at level 20, format "'ℝ\' A").
 
@@ -79,9 +86,13 @@ Local Ltac2 unfold_complement (statement : constr) := eval unfold complement, pr
 
 Ltac2 Notation "Expand" "the" "definition" "of" "ℝ\" "in" statement(constr) := 
   unfold_in_statement unfold_complement (Some "ℝ\") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "ℝ\" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_complement (Some "ℝ\") statement.
 
 Ltac2 Notation "Expand" "the" "definition" "of" "complement" "in" statement(constr) := 
   unfold_in_statement unfold_complement (Some "complement") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_complement (Some "complement") statement.
 
 Notation "A 'is' '_closed_'" := (is_closed A) (at level 68).
 
@@ -91,7 +102,8 @@ Local Ltac2 unfold_is_closed (statement : constr) := eval unfold is_closed in $s
 
 Ltac2 Notation "Expand" "the" "definition" "of" "closed" "in" statement(constr) :=
   unfold_in_statement unfold_is_closed (Some "closed") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "closed" "in" statement(constr) :=
+  unfold_in_statement_no_error unfold_is_closed (Some "closed") statement.
 
 (** Hints *)
 Lemma zero_in_interval_closed_zero_open_one : (0 : [0,1)).

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -360,6 +360,8 @@ Notation "a 'is' 'bounded'" := (is_bounded a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded (statement : constr) := eval unfold is_bounded in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "in" statement(constr) := 
   unfold_in_statement unfold_is_bounded (Some "bounded") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_bounded (Some "bounded") statement.
 
 Definition is_bounded_equivalent (a : ℕ → ℝ) :=
   ∃ M : ℝ, M > 0 ∧ 
@@ -434,6 +436,8 @@ Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 20, only p
 Local Ltac2 unfold_is_bounded_above (statement : constr) := eval unfold is_bounded_above in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" "in" statement(constr) := 
   unfold_in_statement unfold_is_bounded_above (Some "bounded above") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_bounded_above (Some "bounded above") statement.
 
 Definition is_bounded_below (a : ℕ → ℝ) :=
   ∃ m : ℝ, ∀ n : ℕ, m ≤ a(n).
@@ -442,7 +446,8 @@ Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 20, only p
 Local Ltac2 unfold_is_bounded_below (statement : constr) := eval unfold is_bounded_below in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" "in" statement(constr) := 
   unfold_in_statement unfold_is_bounded_below (Some "bounded below") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_bounded_below (Some "bounded below") statement.
 
 (** Convergence to +∞ and -∞. *)
 Definition diverges_to_plus_infinity (a : ℕ → ℝ) := 
@@ -458,8 +463,13 @@ Local Ltac2 unfold_diverge_plus_infty (statement : constr) :=
   eval unfold diverges_to_plus_infinity in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" "in" statement(constr) := 
   unfold_in_statement unfold_diverge_plus_infty (Some "⟶ ∞") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_diverge_plus_infty (Some "⟶ ∞") statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" "in" statement(constr) := 
   unfold_in_statement unfold_diverge_plus_infty (Some "diverges to ∞") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_diverge_plus_infty (Some "diverges to ∞") statement.
+  
 
 Definition diverges_to_minus_infinity (a : ℕ → ℝ) := 
   ∀ M : ℝ,
@@ -474,7 +484,11 @@ Local Ltac2 unfold_diverge_minus_infty (statement : constr) :=
   eval unfold diverges_to_minus_infinity in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞" "in" statement(constr) := 
   unfold_in_statement unfold_diverge_minus_infty (Some "⟶ -∞") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_diverge_minus_infty (Some "⟶ -∞") statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" "in" statement(constr) := 
   unfold_in_statement unfold_diverge_minus_infty (Some "diverges to -∞") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_diverge_minus_infty (Some "diverges to -∞") statement.
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/SequencesMetric.v
+++ b/theories/Libs/Analysis/SequencesMetric.v
@@ -46,6 +46,8 @@ Notation "a ⟶ c" := (convergence a c) (at level 20) : metric_scope.
 Local Ltac2 unfold_convergence (statement : constr) := eval unfold convergence in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "in" statement(constr) := 
   unfold_in_statement unfold_convergence (Some "⟶") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_convergence (Some "⟶") statement.
 
 (* With -->, waterproof complains, giving the following error:
     Command not supported (No proof-editing in progress)*)
@@ -54,6 +56,8 @@ Notation "a '_converges' 'to_' p" := (convergence a p) (at level 68) : metric_sc
 Notation "a 'converges' 'to' p" := (convergence a p) (at level 68, only parsing) : metric_scope.
 Ltac2 Notation "Expand" "the" "definition" "of" "converges" "to" "in" statement(constr) := 
   unfold_in_statement unfold_convergence (Some "converges to") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "converges" "to" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_convergence (Some "converges to") statement.
 
 (* Index shift*)
 Lemma relation_shift {X : Metric_Space} (a : nat -> Base X) (k : nat) (n : nat) (n_ge_k : (n ≥ k)%nat) : 

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -39,6 +39,8 @@ Local Ltac2 unfold_is_index_sequence (statement : constr) := eval unfold is_inde
 
 Ltac2 Notation "Expand" "the" "definition" "of" "index" "sequence" "in" statement(constr) := 
   unfold_in_statement unfold_is_index_sequence (Some "index sequence") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "index" "sequence" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_index_sequence (Some "index sequence") statement.
 
 
 (** The next definition captures what it means to be an index sequence.*)
@@ -230,12 +232,16 @@ Notation "b 'is' 'a' 'subsequence' 'of' a" := (is_subsequence _ b a) (at level 6
 Local Ltac2 unfold_is_subsequence (statement : constr) := eval unfold is_subsequence in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" "in" statement(constr) := 
   unfold_in_statement unfold_is_subsequence (Some "subsequence") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_subsequence (Some "subsequence") statement.
 
 Notation "p 'is' 'an' '_accumulation' 'point_' 'of' a" := (is_accumulation_point _ p a) (at level 68) : metric_scope.
 Notation "p 'is' 'an' 'accumulation' 'point' 'of' a" := (is_accumulation_point _ p a) (at level 68, only parsing) : metric_scope.
 Local Ltac2 unfold_is_accumulation_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" "in" statement(constr) := 
   unfold_in_statement unfold_is_accumulation_point (Some "accumulation point") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation point" "in" statement(constr) := 
+  unfold_in_statement_no_error unfold_is_accumulation_point (Some "accumulation point") statement.
 
 
 #[export] Hint Resolve index_sequence_property : subsequences.

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -37,18 +37,24 @@ Notation "M 'is' 'the' 'supremum' 'of' A" := (is_lub A M) (at level 69, only par
 Local Ltac2 unfold_is_lub (statement : constr) := eval unfold is_lub in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "supremum" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_lub (Some "supremum") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "supremum" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_lub (Some "supremum") statement.
 
 Notation "A 'is' '_bounded' 'from' 'above_'" := (bound A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'above'" := (bound A) (at level 69, only parsing).
 Local Ltac2 unfold_bound (statement : constr) := eval unfold bound in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "above" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_bound (Some "bounded from above") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "above" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_bound (Some "bounded from above") statement.
 
 Notation "M 'is' 'an' '_upper' 'bound_' 'for' A" := (is_upper_bound A M) (at level 69).
 Notation "M 'is' 'an' 'upper' 'bound' 'for' A" := (is_upper_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_upper_bound (statement : constr) := eval unfold is_upper_bound in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "upper" "bound" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_upper_bound (Some "upper bound") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "upper" "bound" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_upper_bound (Some "upper bound") statement.
 
 (** Maximum *)
 Definition is_max (A : ℝ -> Prop) (x : ℝ) := (A x) ∧ (x is an upper bound for A).
@@ -58,7 +64,8 @@ Notation "M 'is' 'the' 'maximum' 'of' A" := (is_max A M) (at level 69, only pars
 Local Ltac2 unfold_is_max (statement : constr) := eval unfold is_max in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "maximum" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_max (Some "maximum") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "maximum" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_max (Some "maximum") statement.
 
 
 (** ## The completeness axiom
@@ -106,6 +113,8 @@ Notation "m 'is' 'the' 'infimum' 'of' A" := (is_inf A m) (at level 69, only pars
 Local Ltac2 unfold_is_inf (statement : constr) := eval unfold is_inf in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "infimum" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_inf (Some "infimum") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "infimum" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_inf (Some "infimum") statement.
 
 Notation "A 'is' '_bounded' 'from' 'below_'" := (is_bounded_below A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'below'" := (is_bounded_below A) (at level 69, only parsing).
@@ -113,13 +122,17 @@ Local Ltac2 unfold_is_bounded_below (statement : constr) :=
   eval unfold is_bounded_below in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "below" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_bounded_below (Some "bounded from below") statement.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "below" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_bounded_below (Some "bounded from below") statement.
+  
 
 Notation "M 'is' 'a' '_lower' 'bound_' 'for' A" := (is_lower_bound A M) (at level 69).
 Notation "M 'is' 'a' 'lower' 'bound' 'for' A" := (is_lower_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_lower_bound (statement : constr) := eval unfold is_lower_bound in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "lower" "bound" "in" statement(constr) := 
   Unfold.unfold_in_statement unfold_is_lower_bound (Some "lower bound") statement.
-
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "lower" "bound" "in" statement(constr) := 
+  Unfold.unfold_in_statement_no_error unfold_is_lower_bound (Some "lower bound") statement.
 
 (** ## Reflection of a subset of ℝ in the origin
 

--- a/theories/Tactics/Unfold.v
+++ b/theories/Tactics/Unfold.v
@@ -40,7 +40,7 @@ Ltac2 Type exn ::=  [ Inner ].
         unfolding is deemed to be succesful if [unfold_method statement] =\= [statement]
     - [def_name: string], optional string used for error message when unfolding
         is unsuccesful
-    - [statement : cosntr], term in which definitions are to be unfolded.
+    - [statement : constr], term in which definitions are to be unfolded.
 
   Raises fatal exceptions:
     - always
@@ -72,7 +72,8 @@ Ltac2 unfold_in_statement (unfold_method: constr -> constr)
       end
     | [ |- _ ] =>
       let msg (unfolded : constr) := concat_list
-      [of_string "result: "; of_constr unfolded; of_string "
+      [of_string "result:
+  "; of_constr unfolded; of_string "
 Remove this line to continue."] in
       throw (msg unfolded_statement)
     end    
@@ -81,6 +82,65 @@ Remove this line to continue."] in
     | None => throw (concat_list 
       [of_string "definition does not appear in "; of_constr statement; of_string "."])
     | Some def_name => throw (concat_list 
+      [of_string "'"; of_string def_name; of_string "'";
+        of_string " does not appear in "; of_constr statement; of_string "."])
+    end
+  end.
+
+(**
+  Attemtps to unfold definition(s) in a statement according to specified method. 
+  If succesful it prints a message suggesting the user to
+  use a suitable tactic with the unfolded statement. 
+    E.g. if the statement corresponds with the proof goal, 
+  the user is suggested to use
+    'We need to show that ([statement with unfolded definiton])'.
+
+  Arguments:
+    - [unfold method: constr -> constr], method to be used for unfolding
+        unfolding is deemed to be succesful if [unfold_method statement] =\= [statement]
+    - [def_name: string], optional string used for error message when unfolding
+        is unsuccesful
+    - [statement : constr], term in which definitions are to be unfolded.
+
+  Raises fatal exceptions:
+    - none
+ 
+*)
+Ltac2 unfold_in_statement_no_error (unfold_method: constr -> constr) 
+  (def_name : string option) (statement : constr) := 
+  let unfolded_statement := unfold_method statement in
+  match Constr.equal statement unfolded_statement with
+  | false =>
+    match! goal with
+    | [ |- ?g] => 
+      match Constr.equal g statement with
+      | false => Control.zero Inner
+      | true => 
+        let msg (unfolded : constr) := concat_list
+          [of_string "use:
+  We need to show that "; of_constr unfolded; of_string "."] in
+        print (msg unfolded_statement)
+      end
+    | [_ : ?hyp |- _ ] =>
+      match Constr.equal hyp statement with
+      | false => Control.zero Inner
+      | true => 
+        let msg (unfolded : constr) := concat_list
+          [of_string "use:
+  It holds that "; of_constr unfolded; of_string "."] in
+        print (msg unfolded_statement)
+      end
+    | [ |- _ ] =>
+      let msg (unfolded : constr) := concat_list
+      [of_string "result:
+  "; of_constr unfolded] in
+      print (msg unfolded_statement)
+    end    
+  | true => 
+    match def_name with
+    | None => print (concat_list 
+      [of_string "definition does not appear in "; of_constr statement; of_string "."])
+    | Some def_name => print (concat_list 
       [of_string "'"; of_string def_name; of_string "'";
         of_string " does not appear in "; of_constr statement; of_string "."])
     end


### PR DESCRIPTION
 For internal use by Waterproof editor only.