### PR TITLE
Fix for problems with strong induction for defining index sequence.

### DIFF
--- a/tests/libs/Analysis/StrongInductionIndexSequence.v
+++ b/tests/libs/Analysis/StrongInductionIndexSequence.v
@@ -19,16 +19,16 @@
 Require Import Ltac2.Ltac2.
 Require Import Waterproof.Libs.Analysis.StrongInductionIndexSequence.
 
-Variable P : nat -> Prop.
+Variable Q : nat -> Prop.
 
 
 (* Test 1: without other Waterproof tactics. *)
-Goal (exists n : nat -> nat, is_index_seq n /\ forall k : nat, P (n k)).
+Goal (exists n : nat -> nat, is_index_seq n /\ forall k : nat, Q (n k)).
 Proof.
   Define the index sequence n inductively.
-  - pose (n0 := 0); exists n0.
+  - pose (n_0 := 0); exists n_0.
     admit.
-  - Take k : ℕ and assume n(0), ..., n(k) are defined.
+  - Take k : ℕ and assume n(0),...,n(k) are defined.
     intros H1 H2.
     pose (n_kplus1 := 0); exists n_kplus1.
     split.
@@ -39,18 +39,56 @@ Abort.
 
 (* Test 2: with other Waterproof tactics. *)
 Require Import Waterproof.Tactics.
-Goal (exists n : nat -> nat, is_index_seq n /\ forall k : nat, P (n k)).
+Goal (exists n : nat -> nat, is_index_seq n /\ forall k : nat, Q (n k)).
 Proof.
   Define the index sequence n inductively.
   - Choose n0 := 0.
     admit.
-  - Take k : ℕ and assume n(0), ..., n(k) are defined.
-    Assume that (forall l : nat, l <= k -> P (n l)).
+  - Take k : ℕ and assume n(0),...,n(k) are defined.
+    Assume that (forall l : nat, l <= k -> Q (n l)).
     Assume that (forall l : nat, l < k -> n l < n (l + 1)).
     Choose n_kplus1 := 0.
     We show both statements.
-    + We need to show that (P n_kplus1).
+    + We need to show that (Q n_kplus1).
       admit.
     + We need to show that (n k < n_kplus1).
       admit.
 Abort.
+
+
+
+(* Test 3:  more complicated example from actual exercises,
+    i.e. with function notation 'n(k)' and 'P(n(k)) = blue' as property. *)
+Require Import Waterproof.Notations.
+Require Import Waterproof.Automation.
+
+Waterproof Enable Automation RealsAndIntegers.
+Waterproof Enable Automation Intuition.
+
+Inductive Color : Set :=
+| blue : Color
+| orange : Color.
+
+Variable P : ℕ → Color.
+Parameter infinitely_many_blues : ∀ k : ℕ, ∃ m : ℕ, (m ≥ k)%nat ∧ P(m) = blue.
+
+Lemma exercise_10_7_6 : 
+  ∃ n : ℕ → ℕ, (is_index_seq n) ∧ (∀ k : ℕ, P (n k) = blue).
+Proof.
+Define the index sequence n inductively.
+- By (infinitely_many_blues) it holds that
+    (∃ m : ℕ, (m ≥ 0)%nat ∧ P(m) = blue).
+  Obtain such an m.
+  Choose n_0 := m.
+  We conclude that (P(n_0) = blue).
+- Take k : ℕ and assume n(0),...,n(k) are defined.
+  Assume that (∀ l : ℕ, (l ≤ k)%nat ⇒ P(n(l)) = blue).
+  Assume that (∀ l : ℕ, (l < k)%nat ⇒ (n(l) < n(l+1))%nat).
+  By (infinitely_many_blues) it holds that 
+    (∃ m : ℕ, (m ≥ (n k) + 1)%nat ∧ P(m) = blue).
+  Obtain such an m.
+  Choose n_kplus1 := m.
+  We show both statements.
+  * We conclude that (P(n_kplus1) = blue).
+  * We conclude that (n(k) < n_kplus1)%nat.
+Qed.

--- a/theories/Libs/Analysis/StrongInductionIndexSequence.v
+++ b/theories/Libs/Analysis/StrongInductionIndexSequence.v
@@ -227,7 +227,7 @@ Qed.
 
 
 Theorem strong_ind_index_seq_with_prop {Q : nat -> Prop}
-  (H0 : {n0 : nat | Q n0})
+  (H0 : {n_0 : nat | Q n_0})
   (Hstep : forall (k : nat) (n : nat -> nat),
     (forall l : nat, l <= k -> Q (n l)) -> (forall l : nat, l < k -> n l < n (l + 1)) ->
     {n_kplus1 : nat | Q n_kplus1 /\ n k < n_kplus1})
@@ -267,7 +267,7 @@ Proof.
 Qed.
 
 Theorem classic_strong_ind_index_seq_with_prop {Q : nat -> Prop}
-  (H0 : exists n0 : nat, Q n0)
+  (H0 : exists n_0 : nat, Q n_0)
   (Hstep : forall (k : nat) (n : nat -> nat),
     (forall l : nat, l <= k -> Q (n l)) -> (forall l : nat, l < k -> n l < n (l + 1)) ->
     exists n_kplus1 : nat, Q n_kplus1 /\ n k < n_kplus1)
@@ -303,15 +303,13 @@ Local Ltac2 concat_list (ls : message list) : message :=
 Require Import Waterproof.Util.Goals.
 Require Import Util.MessagesToUser.
 
-
 Local Ltac2 inductive_def_index_seq_n () :=
   lazy_match! goal with
   | [ |- exists n : nat -> nat, is_index_seq n /\ forall k : nat, @?p n k ] => (*@?p*)
-    lazy_match! p with
-    | fun (n : nat -> nat) (k : nat) => ?q (n k) =>
-      apply (@classic_strong_ind_index_seq_with_prop $q);
-      Control.focus 2 2 (fun () => apply StrongIndIndxSeq.unwrap)
-    | _ => throw (of_string "The index sequence cannot be defined using this technique.")
+    let q := eval unfold id in (fun l : nat => $p id l) in
+    match Control.case (fun () => apply (@classic_strong_ind_index_seq_with_prop $q)) with
+    | Val _ => Control.focus 2 2 (fun () => apply StrongIndIndxSeq.unwrap)
+    | Err exn => throw (of_string "The index sequence cannot be defined using this technique.")
     end
   | [ |- _ ] => throw (of_string "The goal is not to define an index sequence.")
   end.
@@ -326,5 +324,5 @@ Local Ltac2 take_first_k () :=
   | [|- _] => throw (of_string "No need to introduce first k elements of sequence n.")
   end.
 
-Ltac2 Notation "Take" "k" ":" "ℕ" "and" "assume" "n(0)," "...," "n(k)" "are" "defined" := 
+Ltac2 Notation "Take" "k" ":" "ℕ" "and" "assume" "n(0),...,n(k)" "are" "defined" := 
   take_first_k ().

--- a/theories/Util/Goals.v
+++ b/theories/Util/Goals.v
@@ -123,11 +123,11 @@ Module StrongIndIndxSeq.
 
 End StrongIndIndxSeq.
 
-Notation "'Add' 'the' 'following' 'line' 'to' 'the' 'proof:' 'Take' 'k' ':' 'ℕ' 'and' 'assume' 'n(0),' '...,' 'n(k)' 'are' 'defined.'" :=
+Notation "'Add' 'the' 'following' 'line' 'to' 'the' 'proof:' 'Take' 'k' ':' 'ℕ' 'and' 'assume' 'n(0),...,n(k)' 'are' 'defined.'" :=
   (StrongIndIndxSeq.Wrapper _) (
     at level 99,
     only printing,
-    format "'[ ' Add  the  following  line  to  the  proof: ']' '//'   Take  k  :  ℕ  and  assume  n(0),  ...,  n(k)  are  defined."
+    format "'[ ' Add  the  following  line  to  the  proof: ']' '//'   Take  k  :  ℕ  and  assume  n(0),...,n(k)  are  defined."
   ).
 
 


### PR DESCRIPTION
- able to use property 'P(n(k)) = blue'
- able to use notation 'n(k)' later on in proof
- suggest 'n_0' instead of 'n0' to be more in line with suggested 'n_kplus1'