### PR TITLE
Rewrite the 'match' statement in Since.v to 'match!'

### DIFF
--- a/theories/Util/Since.v
+++ b/theories/Util/Since.v
@@ -30,19 +30,13 @@ Local Ltac2 get_type (x: constr) : constr := eval unfold type_of in (type_of $x)
 
 Local Ltac2 check_if_not_reference (x : constr) :=
   let type_x := get_type x in
-  match check_constr_equal type_x constr:(Prop) with
-  | true => ()
-  | false => 
-    match check_constr_equal type_x constr:(Set) with
-    | true => ()
-    | false => 
-      match check_constr_equal type_x constr:(Type) with
-      | true => ()
-      | false => throw (concat_list
+  match! type_x with
+  | Prop => ()
+  | Set => ()
+  | Type => ()
+  | _ => throw (concat_list
         [of_string "Cannot use reference "; of_constr x; of_string " with `Since`.
 Try `By "; of_constr x; of_string " ...` instead."])
-      end
-    end
   end.
 
 Local Ltac2 check_if_not_statement (x : constr) :=
@@ -51,17 +45,11 @@ Local Ltac2 check_if_not_statement (x : constr) :=
 Try `Since "; of_constr x; of_string " ...` instead."]
   in
   let type_x := get_type x in
-  match check_constr_equal type_x constr:(Prop) with
-  | true => throw err_msg
-  | false => 
-    match check_constr_equal type_x constr:(Set) with
-    | true => throw err_msg
-    | false => 
-      match check_constr_equal type_x constr:(Type) with
-      | true => throw err_msg
-      | false => ()
-      end
-    end
+  match! type_x with
+  | Prop => throw err_msg
+  | Set => throw err_msg
+  | Type => throw err_msg
+  | _ => ()
   end.
 
 


### PR DESCRIPTION
The 'match!' statement allows for matching on types and thus we can get rid of the nested `match constr_equal` expressions.