### PR TITLE
[build] Fix use of plugin aliases in findlib loading.

### DIFF
--- a/src/databases.mlg
+++ b/src/databases.mlg
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-DECLARE PLUGIN "coq-waterproof.databases"
+DECLARE PLUGIN "coq-waterproof.plugin"
 
 {
 

--- a/theories/Automation/Framework.v
+++ b/theories/Automation/Framework.v
@@ -17,4 +17,4 @@
 (******************************************************************************)
 
 From Ltac2 Require Import Init.
-Declare ML Module "waterproof:coq-waterproof.databases".
+Declare ML Module "coq-waterproof.plugin".

--- a/theories/Waterproof.v
+++ b/theories/Waterproof.v
@@ -17,4 +17,4 @@
 (******************************************************************************)
 
 From Ltac2 Require Import Init.
-Declare ML Module "waterproof:coq-waterproof.plugin".
+Declare ML Module "coq-waterproof.plugin".


### PR DESCRIPTION
Note that both lines where loading the same plugin, but activating different syntax rules; that's not really allowed as it leaves the system in a partial state. If something like that is needed, true two plugins are necessary (Which is not hard to support nowadays).