### PR TITLE
feat: 'Expand definition' tactic unfolds definition in all statements

### DIFF
--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -28,130 +28,97 @@ Definition foo : nat := 0.
 
 (* Tests general unfolding: *)
 
-(* Test 1: unfold term in statement and throws an error suggesting 
-    to remove line to continue. *)
-Goal False.
-Proof.
-  Fail Expand the definition of foo in foo.
-Abort.
-
-(* Test 2: unfold term in statement matching goal, and throws an error suggesting 
-  to replace line with 'We need to show that ...'. *)
+(* Test 1: unfold term in goal, and throws an error suggesting 
+  to remove the line after use. *)
 Goal foo = 1.
 Proof.
-  Fail Expand the definition of foo in (foo = 1).
+  Fail Expand the definition of foo.
 Abort.
 
-(* Test 3: unfold term in statement matching a hypothesis and throws an error suggesting 
-    to replace line with 'It holds that ...'. *)
+(* Test 2: unfold term in hypothese and goal, and throws an error suggesting 
+    to remove the line after use. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo in (foo = 0).
-  Fail Expand the definition of foo in (foo = 2).
+  Fail Expand the definition of foo.
 Abort.
 
-(* Test 4: fails to unfold term in statment without term. *)
+(* Test 3: fails to unfold term if it does not occur in any statement. *)
 Goal False.
 Proof.
-  Fail Expand the definition of foo in 0.
+  Fail Expand the definition of foo.
 Abort.
 
 
 
 (* Tests framework expand the definition. *)
 Local Ltac2 unfold_foo (statement : constr) := eval unfold foo in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "foo2" "in" statement(constr) := 
-  unfold_in_statement unfold_foo (Some "foo2") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "foo2" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_foo (Some "foo2") true.
 
-(* Test 5: unfold term in statement and throws an error suggesting 
-    to remove line to continue. *)
-Goal False.
-Proof.
-  Fail Expand the definition of foo2 in foo.
-Abort.
-
-(* Test 6: unfold term in statement matching goal, and throws an error suggesting 
-    to replace line with 'We need to show that ...'. *)
-Goal foo = 1.
-Proof.
-  Fail Expand the definition of foo2 in (foo = 1).
-Abort.
-
-(* Test 7: unfold term in statement matching a hypothesis and throws an error suggesting 
-    to replace line with 'It holds that ...'. *)
+(* Test 4: unfold term in hypotheses and goal and throws an error suggesting 
+    to remove line after use. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo2 in (foo = 0).
-  Fail Expand the definition of foo2 in (foo = 2).
+  Fail Expand the definition of foo2.
 Abort.
 
-(* Test 8: fails to unfold term in statment without term. *)
+(* Test 5: fails to unfold term in statment without term. *)
 Goal False.
 Proof.
-  Fail Expand the definition of foo2 in 0.
+  Fail Expand the definition of foo2.
 Abort.
 
 
 (** Check unfolding method that does not throw an error.
   Meant for internal use by custom Waterproof editor. *)
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_foo (Some "foo2") statement.
 
-(* Test 9: unfold term in statement. *)
-Goal False.
-Proof.
-  _internal_ Expand the definition of foo2 in foo.
-Abort.
+(** Non-framework version. *)
 
-(* Test 10: unfold term in statement matching goal, and prints a message suggesting 
-    to replace line with 'We need to show that ...'. *)
-Goal foo = 1.
-Proof.
-  _internal_ Expand the definition of foo2 in (foo = 1).
-Abort.
-
-(* Test 11: unfold term in statement matching a hypothesis and prints a message suggesting 
-    to replace line with 'It holds that ...'. *)
+(* Test 6: unfold term in hypotheses and goal without throwing an error. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  _internal_ Expand the definition of foo2 in (foo = 0).
-  _internal_ Expand the definition of foo2 in (foo = 2).
+  _internal_ Expand the definition of foo.
 Abort.
 
-(* Test 12: fails to unfold term in statment without term. *)
+(* Test 7: unfold fails to unfold term if no statement with term. *)
 Goal False.
 Proof.
-   _internal_ Expand the definition of foo2 in 0.
+  _internal_ Expand the definition of foo.
 Abort.
 
-(* Test 13: internal unfold term in statement and throws an error suggesting 
-    to remove line to continue. *)
-Goal False.
-Proof.
-  _internal_ Expand the definition of foo in foo.
-Abort.
-
-(* Test 14: internal unfold term in statement matching goal, and throws an error suggesting 
-  to replace line with 'We need to show that ...'. *)
-Goal foo = 1.
-Proof.
-  _internal_ Expand the definition of foo in (foo = 1).
-Abort.
-
-(* Test 15: internal unfold term in statement matching a hypothesis and throws an error suggesting 
-    to replace line with 'It holds that ...'. *)
+(* Test 8: outdated format (for format used by Waterproof editor, for now) *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  _internal_ Expand the definition of foo in (foo = 0).
-  _internal_ Expand the definition of foo in (foo = 2).
+  _internal_ Expand the definition of foo in ().
+Abort.
+    
+(** Framework version:  *)
+  
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", "()"))) :=
+  panic_if_goal_wrapped (); 
+  unfold_in_all unfold_foo (Some "foo2") false.
+
+(* Test 9: unfold term in hypotheses and goals. *)
+Goal (foo = 0) -> (foo = 2) -> (foo = 1).
+Proof.
+  intros.
+  _internal_ Expand the definition of foo2.
 Abort.
 
-(* Test 16: internal unfold fails to unfold term in statment without term. *)
+(* Test 10: fails to unfold term if no statements with term. *)
 Goal False.
 Proof.
-  _internal_ Expand the definition of foo in 0.
+   _internal_ Expand the definition of foo2.
+Abort.
+
+(* Test 11: outdated format (for format used by Waterproof editor, for now) *)
+Goal (foo = 0) -> (foo = 2) -> (foo = 1).
+Proof.
+  intros.
+  _internal_ Expand the definition of foo2 in ().
 Abort.

--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -43,19 +43,19 @@ Proof.
   Fail Expand the definition of foo.
 Abort.
 
-(* Test 3: fails to unfold term if it does not occur in any statement. *)
+(* Test 3: Unfold the term in a given statement, throw error suggesting
+    to remove the line after use. *)
 Goal False.
 Proof.
-  Fail Expand the definition of foo.
+  Fail Expand the definition of foo in (foo = 4).
 Abort.
 
 
 
 (* Tests framework expand the definition. *)
 Local Ltac2 unfold_foo (statement : constr) := eval unfold foo in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "foo2" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_foo (Some "foo2") true.
+Ltac2 Notation "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", constr))) := 
+  wp_unfold unfold_foo (Some "foo2") true x.
 
 (* Test 4: unfold term in hypotheses and goal and throws an error suggesting 
     to remove line after use. *)
@@ -94,14 +94,13 @@ Abort.
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  _internal_ Expand the definition of foo in ().
+  _internal_ Expand the definition of foo in (foo = 5).
 Abort.
     
 (** Framework version:  *)
   
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped (); 
-  unfold_in_all unfold_foo (Some "foo2") false.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_foo (Some "foo2") false x.
 
 (* Test 9: unfold term in hypotheses and goals. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
@@ -120,5 +119,5 @@ Abort.
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  _internal_ Expand the definition of foo2 in ().
+  _internal_ Expand the definition of foo2 in (foo = 8).
 Abort.

--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -50,6 +50,22 @@ Proof.
   Fail Expand the definition of foo in (foo = 4).
 Abort.
 
+(* Test 4: Unfold term in given statement that matches goal,
+    throws an error suggesting to remove the line after use. *)
+Goal (foo = 0) -> (foo = 2) -> (foo = 1).
+Proof.
+  intros.
+  Fail Expand the definition of foo in (foo = 1).
+Abort.
+
+(* Test 5: Unfold term in given statement that matches hypothesis,
+    throws an error suggesting to remove the line after use. *)
+Goal (foo = 0) -> (foo = 2) -> (foo = 1).
+Proof.
+  intros.
+  Fail Expand the definition of foo in (foo = 0).
+Abort.
+
 
 
 (* Tests framework expand the definition. *)
@@ -57,7 +73,7 @@ Local Ltac2 unfold_foo (statement : constr) := eval unfold foo in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", constr))) := 
   wp_unfold unfold_foo (Some "foo2") true x.
 
-(* Test 4: unfold term in hypotheses and goal and throws an error suggesting 
+(* Test 6: unfold term in hypotheses and goal and throws an error suggesting 
     to remove line after use. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
@@ -65,7 +81,7 @@ Proof.
   Fail Expand the definition of foo2.
 Abort.
 
-(* Test 5: fails to unfold term in statment without term. *)
+(* Test 7: fails to unfold term in statment without term. *)
 Goal False.
 Proof.
   Fail Expand the definition of foo2.
@@ -77,20 +93,20 @@ Abort.
 
 (** Non-framework version. *)
 
-(* Test 6: unfold term in hypotheses and goal without throwing an error. *)
+(* Test 8: unfold term in hypotheses and goal without throwing an error. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
   _internal_ Expand the definition of foo.
 Abort.
 
-(* Test 7: unfold fails to unfold term if no statement with term. *)
+(* Test 9: unfold fails to unfold term if no statement with term. *)
 Goal False.
 Proof.
   _internal_ Expand the definition of foo.
 Abort.
 
-(* Test 8: outdated format (for format used by Waterproof editor, for now) *)
+(* Test 10: outdated format (for format used by Waterproof editor, for now) *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
@@ -102,20 +118,20 @@ Abort.
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", constr))) :=
   wp_unfold unfold_foo (Some "foo2") false x.
 
-(* Test 9: unfold term in hypotheses and goals. *)
+(* Test 11: unfold term in hypotheses and goals. *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
   _internal_ Expand the definition of foo2.
 Abort.
 
-(* Test 10: fails to unfold term if no statements with term. *)
+(* Test 12: fails to unfold term if no statements with term. *)
 Goal False.
 Proof.
    _internal_ Expand the definition of foo2.
 Abort.
 
-(* Test 11: outdated format (for format used by Waterproof editor, for now) *)
+(* Test 13: outdated format (for format used by Waterproof editor, for now) *)
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.

--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -204,10 +204,12 @@ Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at
 Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
-  unfold_in_statement unfold_acc_point (Some "accumulation point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_acc_point (Some "accumulation point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_acc_point (Some "accumulation point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_acc_point (Some "accumulation point") false.
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
 
@@ -215,10 +217,12 @@ Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68,
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
-  unfold_in_statement unfold_isol_point (Some "isolated point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_isol_point (Some "isolated point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_isol_point (Some "isolated point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_isol_point (Some "isolated point") false.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68).
 
@@ -226,10 +230,12 @@ Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
-  unfold_in_statement unfold_lim_in_point (Some "limit") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_lim_in_point (Some "limit") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "limit" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_lim_in_point (Some "limit") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_lim_in_point (Some "limit") false.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 68).
@@ -238,10 +244,12 @@ Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in _ f a)  (at level 68,
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
-  unfold_in_statement unfold_is_cont (Some "continuous") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_cont (Some "continuous") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "continuous" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_cont (Some "continuous") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_cont (Some "continuous") false.
 
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -204,12 +204,11 @@ Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at
 Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_acc_point (Some "accumulation point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_acc_point (Some "accumulation point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_acc_point (Some "accumulation point") true x.
+
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_acc_point (Some "accumulation point") false x.
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
 
@@ -217,12 +216,10 @@ Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68,
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_isol_point (Some "isolated point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_isol_point (Some "isolated point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_isol_point (Some "isolated point") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_isol_point (Some "isolated point") false x.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68).
 
@@ -230,12 +227,10 @@ Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "limit" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_lim_in_point (Some "limit") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_lim_in_point (Some "limit") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "limit" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_lim_in_point (Some "limit") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_lim_in_point (Some "limit") false x.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 68).
@@ -244,12 +239,10 @@ Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in _ f a)  (at level 68,
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "continuous" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_cont (Some "continuous") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_cont (Some "continuous") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_cont (Some "continuous") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_cont (Some "continuous") false x.
 
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -118,10 +118,12 @@ Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at
 Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
-  unfold_in_statement unfold_acc_point (Some "accumulation point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_acc_point (Some "accumulation point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_acc_point (Some "accumulation point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_acc_point (Some "accumulation point") false.
 
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
@@ -130,10 +132,12 @@ Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68,
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
-  unfold_in_statement unfold_isol_point (Some "isolated point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_isol_point (Some "isolated point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_isol_point (Some "isolated point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_isol_point (Some "isolated point") false.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68).
 
@@ -141,10 +145,12 @@ Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68, 
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
-  unfold_in_statement unfold_lim_in_point (Some "limit") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_lim_in_point (Some "limit") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "limit" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_lim_in_point (Some "limit") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_lim_in_point (Some "limit") false.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in f a) (at level 68).
@@ -153,9 +159,11 @@ Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in f a)  (at level 68, o
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
-  unfold_in_statement unfold_is_cont (Some "continuous") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_cont (Some "continuous") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "continuous" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_cont (Some "continuous") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_cont (Some "continuous") false.
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -118,12 +118,10 @@ Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at
 Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_acc_point (Some "accumulation point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_acc_point (Some "accumulation point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_acc_point (Some "accumulation point") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_acc_point (Some "accumulation point") false x.
 
 
 Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
@@ -132,12 +130,10 @@ Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68,
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_isol_point (Some "isolated point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_isol_point (Some "isolated point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_isol_point (Some "isolated point") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_isol_point (Some "isolated point") false x.
 
 Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68).
 
@@ -145,12 +141,10 @@ Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68, 
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "limit" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_lim_in_point (Some "limit") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_lim_in_point (Some "limit") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "limit" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_lim_in_point (Some "limit") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_lim_in_point (Some "limit") false x.
 
 
 Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in f a) (at level 68).
@@ -159,11 +153,9 @@ Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in f a)  (at level 68, o
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "continuous" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_cont (Some "continuous") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_cont (Some "continuous") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_cont (Some "continuous") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "continuous" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_cont (Some "continuous") false x.
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -46,19 +46,15 @@ Notation "B( p , r )" := (open_ball p r) (at level 68, format "B( p ,  r )").
 
 Local Ltac2 unfold_open_ball (statement : constr) := eval unfold open_ball, pred in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "B" :=
-  panic_if_goal_wrapped (); 
-  unfold_in_all unfold_open_ball (Some "B") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "B" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_open_ball (Some "B") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "B" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_open_ball (Some "B") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "B" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_open_ball (Some "B") false x.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_open_ball (Some "open ball ") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_open_ball (Some "open ball ") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_open_ball (Some "open ball ") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_open_ball (Some "open ball ") false x.
 
 Notation "a 'is' 'an' '_interior' 'point_' 'of' A" := (is_interior_point a A) (at level 68).
 
@@ -66,12 +62,10 @@ Notation "a 'is' 'an' 'interior' 'point' 'of' A" := (is_interior_point a A) (at 
 
 Local Ltac2 unfold_is_interior_point (statement : constr) := eval unfold is_interior_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_interior_point (Some "interior point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_interior_point (Some "interior point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_interior_point (Some "interior point") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_interior_point (Some "interior point") false x.
 
 Notation "A 'is' '_open_'" := (is_open A) (at level 68).
 
@@ -79,12 +73,10 @@ Notation "A 'is' 'open'" := (is_open A) (at level 68, only parsing).
 
 Local Ltac2 unfold_is_open (statement : constr) := eval unfold is_open in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "open" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_open (Some "open") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_open (Some "open") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "open" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_open (Some "open") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_open (Some "open") false x.
 
 Notation "'ℝ\' A" := (complement A) (at level 20, format "'ℝ\' A").
 
@@ -92,19 +84,15 @@ Notation "'ℝ' '\' A" := (complement A) (at level 20, only parsing).
 
 Local Ltac2 unfold_complement (statement : constr) := eval unfold complement, pred in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "ℝ\" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_complement (Some "ℝ\") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "ℝ\" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_complement (Some "ℝ\") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "ℝ\" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_complement (Some "ℝ\") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "ℝ\" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_complement (Some "ℝ\") false x.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "complement" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_complement (Some "complement") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_complement (Some "complement") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "complement" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_complement (Some "complement") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_complement (Some "complement") false x.
 
 Notation "A 'is' '_closed_'" := (is_closed A) (at level 68).
 
@@ -112,12 +100,10 @@ Notation "A 'is' 'closed'" := (is_closed A) (at level 68, only parsing).
 
 Local Ltac2 unfold_is_closed (statement : constr) := eval unfold is_closed in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "closed" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_closed (Some "closed") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "closed" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_closed (Some "closed") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "closed" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_closed (Some "closed") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "closed" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_closed (Some "closed") false x.
 
 (** Hints *)
 Lemma zero_in_interval_closed_zero_open_one : (0 : [0,1)).

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -46,15 +46,19 @@ Notation "B( p , r )" := (open_ball p r) (at level 68, format "B( p ,  r )").
 
 Local Ltac2 unfold_open_ball (statement : constr) := eval unfold open_ball, pred in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "B" "in" statement(constr) := 
-  unfold_in_statement unfold_open_ball (Some "B") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "B" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_open_ball (Some "B") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "B" :=
+  panic_if_goal_wrapped (); 
+  unfold_in_all unfold_open_ball (Some "B") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "B" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_open_ball (Some "B") false.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" "in" statement(constr) := 
-  unfold_in_statement unfold_open_ball (Some "open ball ") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_open_ball (Some "open ball ") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_open_ball (Some "open ball ") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_open_ball (Some "open ball ") false.
 
 Notation "a 'is' 'an' '_interior' 'point_' 'of' A" := (is_interior_point a A) (at level 68).
 
@@ -62,10 +66,12 @@ Notation "a 'is' 'an' 'interior' 'point' 'of' A" := (is_interior_point a A) (at 
 
 Local Ltac2 unfold_is_interior_point (statement : constr) := eval unfold is_interior_point in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" "in" statement(constr) := 
-  unfold_in_statement unfold_is_interior_point (Some "interior point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_interior_point (Some "interior point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_interior_point (Some "interior point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_interior_point (Some "interior point") false.
 
 Notation "A 'is' '_open_'" := (is_open A) (at level 68).
 
@@ -73,10 +79,12 @@ Notation "A 'is' 'open'" := (is_open A) (at level 68, only parsing).
 
 Local Ltac2 unfold_is_open (statement : constr) := eval unfold is_open in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "open" "in" statement(constr) := 
-  unfold_in_statement unfold_is_open (Some "open") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_open (Some "open") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "open" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_open (Some "open") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_open (Some "open") false.
 
 Notation "'ℝ\' A" := (complement A) (at level 20, format "'ℝ\' A").
 
@@ -84,15 +92,19 @@ Notation "'ℝ' '\' A" := (complement A) (at level 20, only parsing).
 
 Local Ltac2 unfold_complement (statement : constr) := eval unfold complement, pred in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "ℝ\" "in" statement(constr) := 
-  unfold_in_statement unfold_complement (Some "ℝ\") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "ℝ\" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_complement (Some "ℝ\") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "ℝ\" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_complement (Some "ℝ\") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "ℝ\" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_complement (Some "ℝ\") false.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "complement" "in" statement(constr) := 
-  unfold_in_statement unfold_complement (Some "complement") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_complement (Some "complement") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "complement" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_complement (Some "complement") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_complement (Some "complement") false.
 
 Notation "A 'is' '_closed_'" := (is_closed A) (at level 68).
 
@@ -100,10 +112,12 @@ Notation "A 'is' 'closed'" := (is_closed A) (at level 68, only parsing).
 
 Local Ltac2 unfold_is_closed (statement : constr) := eval unfold is_closed in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "closed" "in" statement(constr) :=
-  unfold_in_statement unfold_is_closed (Some "closed") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "closed" "in" statement(constr) :=
-  unfold_in_statement_no_error unfold_is_closed (Some "closed") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "closed" :=
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_closed (Some "closed") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "closed" x(opt(seq("in", "()"))) :=
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_closed (Some "closed") false.
 
 (** Hints *)
 Lemma zero_in_interval_closed_zero_open_one : (0 : [0,1)).

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -358,10 +358,12 @@ Definition is_bounded (a : ℕ → ℝ) :=
 Notation "a 'is' '_bounded_'" := (is_bounded a) (at level 20).
 Notation "a 'is' 'bounded'" := (is_bounded a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded (statement : constr) := eval unfold is_bounded in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "in" statement(constr) := 
-  unfold_in_statement unfold_is_bounded (Some "bounded") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_bounded (Some "bounded") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded (Some "bounded") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded (Some "bounded") false.
 
 Definition is_bounded_equivalent (a : ℕ → ℝ) :=
   ∃ M : ℝ, M > 0 ∧ 
@@ -434,20 +436,24 @@ Definition is_bounded_above (a : ℕ → ℝ) :=
 Notation "a 'is' '_bounded' 'above_'" := (is_bounded_above a) (at level 20).
 Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_above (statement : constr) := eval unfold is_bounded_above in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" "in" statement(constr) := 
-  unfold_in_statement unfold_is_bounded_above (Some "bounded above") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_bounded_above (Some "bounded above") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_above (Some "bounded above") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_above (Some "bounded above") false.
 
 Definition is_bounded_below (a : ℕ → ℝ) :=
   ∃ m : ℝ, ∀ n : ℕ, m ≤ a(n).
 Notation "a 'is' '_bounded' 'below_'" := (is_bounded_below a) (at level 20).
 Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_below (statement : constr) := eval unfold is_bounded_below in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" "in" statement(constr) := 
-  unfold_in_statement unfold_is_bounded_below (Some "bounded below") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_bounded_below (Some "bounded below") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_below (Some "bounded below") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_below (Some "bounded below") false.
 
 (** Convergence to +∞ and -∞. *)
 Definition diverges_to_plus_infinity (a : ℕ → ℝ) := 
@@ -461,14 +467,18 @@ Notation "a '_diverges' 'to' '∞_'" := (diverges_to_plus_infinity a) (at level 
 Notation "a 'diverges' 'to' '∞'"   := (diverges_to_plus_infinity a) (at level 20, only parsing).
 Local Ltac2 unfold_diverge_plus_infty (statement : constr) := 
   eval unfold diverges_to_plus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" "in" statement(constr) := 
-  unfold_in_statement unfold_diverge_plus_infty (Some "⟶ ∞") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_diverge_plus_infty (Some "⟶ ∞") statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" "in" statement(constr) := 
-  unfold_in_statement unfold_diverge_plus_infty (Some "diverges to ∞") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_diverge_plus_infty (Some "diverges to ∞") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") false.
   
 
 Definition diverges_to_minus_infinity (a : ℕ → ℝ) := 
@@ -482,13 +492,17 @@ Notation "a '_diverges' 'to' '-∞_'" := (diverges_to_minus_infinity a) (at leve
 Notation "a 'diverges' 'to' '-∞'"   := (diverges_to_minus_infinity a) (at level 20, only parsing).
 Local Ltac2 unfold_diverge_minus_infty (statement : constr) := 
   eval unfold diverges_to_minus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞" "in" statement(constr) := 
-  unfold_in_statement unfold_diverge_minus_infty (Some "⟶ -∞") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_diverge_minus_infty (Some "⟶ -∞") statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" "in" statement(constr) := 
-  unfold_in_statement unfold_diverge_minus_infty (Some "diverges to -∞") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_diverge_minus_infty (Some "diverges to -∞") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞":= 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") false.
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/SequencesMetric.v
+++ b/theories/Libs/Analysis/SequencesMetric.v
@@ -44,24 +44,20 @@ Definition bounded {X : Metric_Space} (a : ℕ → Base X) :=
 Declare Scope metric_scope.
 Notation "a ⟶ c" := (convergence a c) (at level 20) : metric_scope.
 Local Ltac2 unfold_convergence (statement : constr) := eval unfold convergence in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_convergence (Some "⟶") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_convergence (Some "⟶") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_convergence (Some "⟶") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_convergence (Some "⟶") false x.
 
 (* With -->, waterproof complains, giving the following error:
     Command not supported (No proof-editing in progress)*)
 
 Notation "a '_converges' 'to_' p" := (convergence a p) (at level 68) : metric_scope.
 Notation "a 'converges' 'to' p" := (convergence a p) (at level 68, only parsing) : metric_scope.
-Ltac2 Notation "Expand" "the" "definition" "of" "converges" "to" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_convergence (Some "converges to") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "converges" "to" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_convergence (Some "converges to") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "converges" "to" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_convergence (Some "converges to") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "converges" "to" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_convergence (Some "converges to") false x.
 
 (* Index shift*)
 Lemma relation_shift {X : Metric_Space} (a : nat -> Base X) (k : nat) (n : nat) (n_ge_k : (n ≥ k)%nat) : 

--- a/theories/Libs/Analysis/SequencesMetric.v
+++ b/theories/Libs/Analysis/SequencesMetric.v
@@ -44,20 +44,24 @@ Definition bounded {X : Metric_Space} (a : ℕ → Base X) :=
 Declare Scope metric_scope.
 Notation "a ⟶ c" := (convergence a c) (at level 20) : metric_scope.
 Local Ltac2 unfold_convergence (statement : constr) := eval unfold convergence in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "in" statement(constr) := 
-  unfold_in_statement unfold_convergence (Some "⟶") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_convergence (Some "⟶") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_convergence (Some "⟶") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_convergence (Some "⟶") false.
 
 (* With -->, waterproof complains, giving the following error:
     Command not supported (No proof-editing in progress)*)
 
 Notation "a '_converges' 'to_' p" := (convergence a p) (at level 68) : metric_scope.
 Notation "a 'converges' 'to' p" := (convergence a p) (at level 68, only parsing) : metric_scope.
-Ltac2 Notation "Expand" "the" "definition" "of" "converges" "to" "in" statement(constr) := 
-  unfold_in_statement unfold_convergence (Some "converges to") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "converges" "to" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_convergence (Some "converges to") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "converges" "to" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_convergence (Some "converges to") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "converges" "to" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_convergence (Some "converges to") false.
 
 (* Index shift*)
 Lemma relation_shift {X : Metric_Space} (a : nat -> Base X) (k : nat) (n : nat) (n_ge_k : (n ≥ k)%nat) : 

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -37,12 +37,10 @@ Notation "n 'is' 'an' 'index' 'sequence'" := (is_index_sequence n) (at level 68,
 
 Local Ltac2 unfold_is_index_sequence (statement : constr) := eval unfold is_index_sequence in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "index" "sequence" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_index_sequence (Some "index sequence") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "index" "sequence" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_index_sequence (Some "index sequence") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "index" "sequence" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_index_sequence (Some "index sequence") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "index" "sequence" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_index_sequence (Some "index sequence") false x.
 
 
 (** The next definition captures what it means to be an index sequence.*)
@@ -232,22 +230,18 @@ End my_section.
 Notation "b 'is' 'a' '_subsequence_' 'of' a" := (is_subsequence _ b a) (at level 68) : metric_scope.
 Notation "b 'is' 'a' 'subsequence' 'of' a" := (is_subsequence _ b a) (at level 68, only parsing) : metric_scope.
 Local Ltac2 unfold_is_subsequence (statement : constr) := eval unfold is_subsequence in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_subsequence (Some "subsequence") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_subsequence (Some "subsequence") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_subsequence (Some "subsequence") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_subsequence (Some "subsequence") false x.
 
 Notation "p 'is' 'an' '_accumulation' 'point_' 'of' a" := (is_accumulation_point _ p a) (at level 68) : metric_scope.
 Notation "p 'is' 'an' 'accumulation' 'point' 'of' a" := (is_accumulation_point _ p a) (at level 68, only parsing) : metric_scope.
 Local Ltac2 unfold_is_accumulation_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_accumulation_point (Some "accumulation point") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation point" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_accumulation_point (Some "accumulation point") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_accumulation_point (Some "accumulation point") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation point" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_accumulation_point (Some "accumulation point") false x.
 
 
 #[export] Hint Resolve index_sequence_property : subsequences.

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -37,10 +37,12 @@ Notation "n 'is' 'an' 'index' 'sequence'" := (is_index_sequence n) (at level 68,
 
 Local Ltac2 unfold_is_index_sequence (statement : constr) := eval unfold is_index_sequence in $statement.
 
-Ltac2 Notation "Expand" "the" "definition" "of" "index" "sequence" "in" statement(constr) := 
-  unfold_in_statement unfold_is_index_sequence (Some "index sequence") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "index" "sequence" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_index_sequence (Some "index sequence") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "index" "sequence" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_index_sequence (Some "index sequence") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "index" "sequence" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_index_sequence (Some "index sequence") false.
 
 
 (** The next definition captures what it means to be an index sequence.*)
@@ -230,18 +232,22 @@ End my_section.
 Notation "b 'is' 'a' '_subsequence_' 'of' a" := (is_subsequence _ b a) (at level 68) : metric_scope.
 Notation "b 'is' 'a' 'subsequence' 'of' a" := (is_subsequence _ b a) (at level 68, only parsing) : metric_scope.
 Local Ltac2 unfold_is_subsequence (statement : constr) := eval unfold is_subsequence in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" "in" statement(constr) := 
-  unfold_in_statement unfold_is_subsequence (Some "subsequence") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_subsequence (Some "subsequence") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_subsequence (Some "subsequence") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_subsequence (Some "subsequence") false.
 
 Notation "p 'is' 'an' '_accumulation' 'point_' 'of' a" := (is_accumulation_point _ p a) (at level 68) : metric_scope.
 Notation "p 'is' 'an' 'accumulation' 'point' 'of' a" := (is_accumulation_point _ p a) (at level 68, only parsing) : metric_scope.
 Local Ltac2 unfold_is_accumulation_point (statement : constr) := eval unfold is_accumulation_point in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" "in" statement(constr) := 
-  unfold_in_statement unfold_is_accumulation_point (Some "accumulation point") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation point" "in" statement(constr) := 
-  unfold_in_statement_no_error unfold_is_accumulation_point (Some "accumulation point") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_accumulation_point (Some "accumulation point") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation point" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_accumulation_point (Some "accumulation point") false.
 
 
 #[export] Hint Resolve index_sequence_property : subsequences.

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -35,32 +35,26 @@ Notation is_sup := is_lub.
 Notation "M 'is' 'the' '_supremum_' 'of' A" := (is_lub A M) (at level 69).
 Notation "M 'is' 'the' 'supremum' 'of' A" := (is_lub A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_lub (statement : constr) := eval unfold is_lub in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "supremum" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_lub (Some "supremum") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "supremum" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_lub (Some "supremum") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "supremum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_lub (Some "supremum") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "supremum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_lub (Some "supremum") false x.
 
 Notation "A 'is' '_bounded' 'from' 'above_'" := (bound A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'above'" := (bound A) (at level 69, only parsing).
 Local Ltac2 unfold_bound (statement : constr) := eval unfold bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "above" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_bound (Some "bounded from above") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "above" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_bound (Some "bounded from above") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "above" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_bound (Some "bounded from above") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "above" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_bound (Some "bounded from above") false x.
 
 Notation "M 'is' 'an' '_upper' 'bound_' 'for' A" := (is_upper_bound A M) (at level 69).
 Notation "M 'is' 'an' 'upper' 'bound' 'for' A" := (is_upper_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_upper_bound (statement : constr) := eval unfold is_upper_bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "upper" "bound" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_upper_bound (Some "upper bound") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "upper" "bound" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_upper_bound (Some "upper bound") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "upper" "bound" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_upper_bound (Some "upper bound") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "upper" "bound" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_upper_bound (Some "upper bound") false x.
 
 (** Maximum *)
 Definition is_max (A : ℝ -> Prop) (x : ℝ) := (A x) ∧ (x is an upper bound for A).
@@ -68,13 +62,10 @@ Definition is_max (A : ℝ -> Prop) (x : ℝ) := (A x) ∧ (x is an upper bound 
 Notation "M 'is' 'the' '_maximum_' 'of' A" := (is_max A M) (at level 69).
 Notation "M 'is' 'the' 'maximum' 'of' A" := (is_max A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_max (statement : constr) := eval unfold is_max in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "maximum" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_max (Some "maximum") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "maximum" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_max (Some "maximum") false.
-
+Ltac2 Notation "Expand" "the" "definition" "of" "maximum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_max (Some "maximum") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "maximum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_max (Some "maximum") false x.
 
 (** ## The completeness axiom
 
@@ -119,34 +110,28 @@ Definition is_inf :=
 Notation "m 'is' 'the' '_infimum_' 'of' A" := (is_inf A m) (at level 69).
 Notation "m 'is' 'the' 'infimum' 'of' A" := (is_inf A m) (at level 69, only parsing).
 Local Ltac2 unfold_is_inf (statement : constr) := eval unfold is_inf in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "infimum" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_inf (Some "infimum") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "infimum" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_inf (Some "infimum") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "infimum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_inf (Some "infimum") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "infimum" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_inf (Some "infimum") false x.
 
 Notation "A 'is' '_bounded' 'from' 'below_'" := (is_bounded_below A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'below'" := (is_bounded_below A) (at level 69, only parsing).
-Local Ltac2 unfold_is_bounded_below (statement : constr) := 
+Local Ltac2 unfold_is_bounded_below (statement : constr) :=
   eval unfold is_bounded_below in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "below" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_below (Some "bounded from below") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "below" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_below (Some "bounded from below") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "below" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded_below (Some "bounded from below") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "below" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded_below (Some "bounded from below") false x.
   
 
 Notation "M 'is' 'a' '_lower' 'bound_' 'for' A" := (is_lower_bound A M) (at level 69).
 Notation "M 'is' 'a' 'lower' 'bound' 'for' A" := (is_lower_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_lower_bound (statement : constr) := eval unfold is_lower_bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "lower" "bound" := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_lower_bound (Some "lower bound") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "lower" "bound" x(opt(seq("in", "()"))) := 
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_lower_bound (Some "lower bound") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "lower" "bound" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_lower_bound (Some "lower bound") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "lower" "bound" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_lower_bound (Some "lower bound") false x.
 
 (** ## Reflection of a subset of ℝ in the origin
 

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -35,26 +35,32 @@ Notation is_sup := is_lub.
 Notation "M 'is' 'the' '_supremum_' 'of' A" := (is_lub A M) (at level 69).
 Notation "M 'is' 'the' 'supremum' 'of' A" := (is_lub A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_lub (statement : constr) := eval unfold is_lub in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "supremum" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_lub (Some "supremum") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "supremum" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_lub (Some "supremum") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "supremum" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_lub (Some "supremum") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "supremum" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_lub (Some "supremum") false.
 
 Notation "A 'is' '_bounded' 'from' 'above_'" := (bound A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'above'" := (bound A) (at level 69, only parsing).
 Local Ltac2 unfold_bound (statement : constr) := eval unfold bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "above" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_bound (Some "bounded from above") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "above" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_bound (Some "bounded from above") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "above" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_bound (Some "bounded from above") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "above" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_bound (Some "bounded from above") false.
 
 Notation "M 'is' 'an' '_upper' 'bound_' 'for' A" := (is_upper_bound A M) (at level 69).
 Notation "M 'is' 'an' 'upper' 'bound' 'for' A" := (is_upper_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_upper_bound (statement : constr) := eval unfold is_upper_bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "upper" "bound" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_upper_bound (Some "upper bound") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "upper" "bound" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_upper_bound (Some "upper bound") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "upper" "bound" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_upper_bound (Some "upper bound") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "upper" "bound" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_upper_bound (Some "upper bound") false.
 
 (** Maximum *)
 Definition is_max (A : ℝ -> Prop) (x : ℝ) := (A x) ∧ (x is an upper bound for A).
@@ -62,10 +68,12 @@ Definition is_max (A : ℝ -> Prop) (x : ℝ) := (A x) ∧ (x is an upper bound 
 Notation "M 'is' 'the' '_maximum_' 'of' A" := (is_max A M) (at level 69).
 Notation "M 'is' 'the' 'maximum' 'of' A" := (is_max A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_max (statement : constr) := eval unfold is_max in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "maximum" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_max (Some "maximum") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "maximum" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_max (Some "maximum") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "maximum" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_max (Some "maximum") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "maximum" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_max (Some "maximum") false.
 
 
 (** ## The completeness axiom
@@ -111,28 +119,34 @@ Definition is_inf :=
 Notation "m 'is' 'the' '_infimum_' 'of' A" := (is_inf A m) (at level 69).
 Notation "m 'is' 'the' 'infimum' 'of' A" := (is_inf A m) (at level 69, only parsing).
 Local Ltac2 unfold_is_inf (statement : constr) := eval unfold is_inf in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "infimum" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_inf (Some "infimum") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "infimum" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_inf (Some "infimum") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "infimum" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_inf (Some "infimum") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "infimum" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_inf (Some "infimum") false.
 
 Notation "A 'is' '_bounded' 'from' 'below_'" := (is_bounded_below A) (at level 69).
 Notation "A 'is' 'bounded' 'from' 'below'" := (is_bounded_below A) (at level 69, only parsing).
 Local Ltac2 unfold_is_bounded_below (statement : constr) := 
   eval unfold is_bounded_below in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "below" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_bounded_below (Some "bounded from below") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "below" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_bounded_below (Some "bounded from below") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "from" "below" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_below (Some "bounded from below") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "from" "below" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_bounded_below (Some "bounded from below") false.
   
 
 Notation "M 'is' 'a' '_lower' 'bound_' 'for' A" := (is_lower_bound A M) (at level 69).
 Notation "M 'is' 'a' 'lower' 'bound' 'for' A" := (is_lower_bound A M) (at level 69, only parsing).
 Local Ltac2 unfold_is_lower_bound (statement : constr) := eval unfold is_lower_bound in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "lower" "bound" "in" statement(constr) := 
-  Unfold.unfold_in_statement unfold_is_lower_bound (Some "lower bound") statement.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "lower" "bound" "in" statement(constr) := 
-  Unfold.unfold_in_statement_no_error unfold_is_lower_bound (Some "lower bound") statement.
+Ltac2 Notation "Expand" "the" "definition" "of" "lower" "bound" := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_lower_bound (Some "lower bound") true.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "lower" "bound" x(opt(seq("in", "()"))) := 
+  panic_if_goal_wrapped ();
+  unfold_in_all unfold_is_lower_bound (Some "lower bound") false.
 
 (** ## Reflection of a subset of ℝ in the origin
 

--- a/theories/Tactics/Unfold.v
+++ b/theories/Tactics/Unfold.v
@@ -81,7 +81,7 @@ Ltac2 unfold_in_statement (unfold_method: constr -> constr)
     | [ |- _ ] =>
       let msg (unfolded : constr) := concat_list
       [of_string "result:
-  "; of_constr unfolded; of_string "."] in
+  "; of_constr unfolded] in
       print (msg unfolded_statement)
     end
   | true =>

--- a/theories/Tactics/Unfold.v
+++ b/theories/Tactics/Unfold.v
@@ -25,14 +25,19 @@ Local Ltac2 concat_list (ls : message list) : message :=
 Require Import Util.Goals.
 Require Import Util.MessagesToUser.
 
-Ltac2 Type exn ::=  [ Inner ].
+Local Ltac2 _is_empty (ls : 'a list) :=
+  match ls with
+  | _::_ => false
+  | []   => true
+  end.
+
+
 
 (**
-  Attemtps to unfold definition(s) in a statement according to specified method. 
-  If succesful it also throws a fatal error suggesting the user to replace this 
-  command by an alternative, suitable tactic with the unfolded statement. 
-    E.g. if the statement corresponds with the proof goal, 
-  the user is suggested to use
+  Attempts to unfold definition(s) in every statement according to specified method. 
+  If succesful it prints a list of suitable tactics
+  that can be used to incorporate the unfolded statements into the user's proof script. 
+    E.g. if the defition was unfolded in the proof goal, the list will include
     'We need to show that ([statement with unfolded definiton])'.
 
   Arguments:
@@ -40,121 +45,80 @@ Ltac2 Type exn ::=  [ Inner ].
         unfolding is deemed to be succesful if [unfold_method statement] =\= [statement]
     - [def_name: string], optional string used for error message when unfolding
         is unsuccesful
-    - [statement : constr], term in which definitions are to be unfolded.
+    - [throw_error : bool], whether the tactic should throw an error which suggests
+        user to remove this tactic in final version of the proof.
 
   Raises fatal exceptions:
-    - always
- 
+    - [always/none] depending on value of [throw_error].
 *)
-Ltac2 unfold_in_statement (unfold_method: constr -> constr) 
-  (def_name : string option) (statement : constr) := 
-  let unfolded_statement := unfold_method statement in
-  match Constr.equal statement unfolded_statement with
-  | false =>
-    match! goal with
-    | [ |- ?g] => 
-      match Constr.equal g statement with
-      | false => Control.zero Inner
-      | true => 
-        let msg (unfolded : constr) := concat_list
-          [of_string "replace line with:
-  We need to show that "; of_constr unfolded; of_string "."] in
-        throw (msg unfolded_statement)
-      end
-    | [_ : ?hyp |- _ ] =>
-      match Constr.equal hyp statement with
-      | false => Control.zero Inner
-      | true => 
-        let msg (unfolded : constr) := concat_list
-          [of_string "replace line with:
-  It holds that "; of_constr unfolded; of_string "."] in
-        throw (msg unfolded_statement)
-      end
-    | [ |- _ ] =>
-      let msg (unfolded : constr) := concat_list
-      [of_string "result:
-  "; of_constr unfolded; of_string "
-Remove this line to continue."] in
-      throw (msg unfolded_statement)
-    end    
-  | true => 
-    match def_name with
-    | None => throw (concat_list 
-      [of_string "definition does not appear in "; of_constr statement; of_string "."])
-    | Some def_name => throw (concat_list 
-      [of_string "'"; of_string def_name; of_string "'";
-        of_string " does not appear in "; of_constr statement; of_string "."])
-    end
-  end.
 
-(**
-  Attemtps to unfold definition(s) in a statement according to specified method. 
-  If succesful it prints a message suggesting the user to
-  use a suitable tactic with the unfolded statement. 
-    E.g. if the statement corresponds with the proof goal, 
-  the user is suggested to use
-    'We need to show that ([statement with unfolded definiton])'.
+Ltac2 unfold_in_all (unfold_method: constr -> constr) 
+  (def_name : string option) (throw_error : bool) :=
 
-  Arguments:
-    - [unfold method: constr -> constr], method to be used for unfolding
-        unfolding is deemed to be succesful if [unfold_method statement] =\= [statement]
-    - [def_name: string], optional string used for error message when unfolding
-        is unsuccesful
-    - [statement : constr], term in which definitions are to be unfolded.
+  
+  let goal := Control.goal () in
+  let unfolded_goal := unfold_method goal in
+  let did_unfold_goal := Bool.neg (Constr.equal unfolded_goal goal) in
 
-  Raises fatal exceptions:
-    - none
- 
-*)
-Ltac2 unfold_in_statement_no_error (unfold_method: constr -> constr) 
-  (def_name : string option) (statement : constr) := 
-  let unfolded_statement := unfold_method statement in
-  match Constr.equal statement unfolded_statement with
-  | false =>
-    match! goal with
-    | [ |- ?g] => 
-      match Constr.equal g statement with
-      | false => Control.zero Inner
-      | true => 
-        let msg (unfolded : constr) := concat_list
-          [of_string "use:
-  We need to show that "; of_constr unfolded; of_string "."] in
-        print (msg unfolded_statement)
-      end
-    | [_ : ?hyp |- _ ] =>
-      match Constr.equal hyp statement with
-      | false => Control.zero Inner
-      | true => 
-        let msg (unfolded : constr) := concat_list
-          [of_string "use:
-  It holds that "; of_constr unfolded; of_string "."] in
-        print (msg unfolded_statement)
-      end
-    | [ |- _ ] =>
-      let msg (unfolded : constr) := concat_list
-      [of_string "result:
-  "; of_constr unfolded] in
-      print (msg unfolded_statement)
-    end    
-  | true => 
-    match def_name with
-    | None => print (concat_list 
-      [of_string "definition does not appear in "; of_constr statement; of_string "."])
-    | Some def_name => print (concat_list 
-      [of_string "'"; of_string def_name; of_string "'";
-        of_string " does not appear in "; of_constr statement; of_string "."])
-    end
-  end.
+  let hyps := List.map (fun (i, def, t) => t) (Control.hyps ()) in
+  let unfolded_hyps := List.map unfold_method hyps in 
+  let only_unfolded_hyps := 
+    List.map (fun (uh, h) => uh) (
+      List.filter_out (fun (uh, h) => Constr.equal uh h) (
+        List.combine unfolded_hyps hyps
+      )
+    ) in
+
+  (* Print output *)
+  if (Bool.or did_unfold_goal (Bool.neg (_is_empty only_unfolded_hyps)))
+    then
+      (* Print initial statement *)
+      print (of_string "Expanded definition in statements where applicable.");
+      print (of_string "To include these statements, use (one of):");
+
+      (* Print unfolded goal *)
+      if did_unfold_goal
+        then 
+          print (of_string "");
+          print (concat_list [of_string "  We need to show that "; 
+            of_constr unfolded_goal; of_string "."])
+        else ();
+
+      (* Print unfolded hypotheses *)
+      if (Bool.neg (_is_empty only_unfolded_hyps))
+        then
+          print (of_string "");
+          let it_holds_msg := fun (x : constr) => concat_list
+            [of_string "  It holds that "; of_constr x; of_string "."] in
+          List.fold_left (fun _ unfolded_h => print (it_holds_msg unfolded_h)) 
+            only_unfolded_hyps ()
+        else ()
+    
+    else
+      (* Print no statements with definition *)
+      match def_name with
+      | None => print (of_string "Definition does not appear in any statement.")
+      | Some def_name => print (concat_list 
+          [of_string "'"; of_string def_name; of_string "'";
+            of_string " does not appear in any statement."])
+      end;
+
+  (* Throw error if required *)
+  if throw_error
+    then throw (of_string "Remove this line in the final version of your proof.")
+    else ().
+
 
 
 (* Tactic notation for unfolding generic Gallinea terms, not notations.
   For an example of how to used [unfold_in_statement] to unfold notations,
   see [tests/tactics/Unfold.v] *)
 
-Ltac2 Notation "Expand" "the" "definition" "of" targets(list1(seq(reference, occurrences), ",")) "in" statement(constr) :=
+Ltac2 Notation "Expand" "the" "definition" "of" targets(list1(seq(reference, occurrences), ",")) :=
   panic_if_goal_wrapped ();
-  unfold_in_statement (eval_unfold targets) None statement.
+  unfold_in_all (eval_unfold targets) None true.
 
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" targets(list1(seq(reference, occurrences), ",")) "in" statement(constr) :=
+(* For now, include optional tail to keep compatible with tactic called by Waterproof editor. *)
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" targets(list1(seq(reference, occurrences), ",")) x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
-  unfold_in_statement_no_error (eval_unfold targets) None statement.
+  unfold_in_all (eval_unfold targets) None false.


### PR DESCRIPTION
Example usage:

```
Definition foo : nat := 0.

Goal (foo = 0) -> (foo = 2) -> (foo = 1).
Proof.
  intros.
  Expand the definition of foo.
Abort.
```

outputs the message

```
Expanded definition in statements where applicable.
To include these statements, use (one of):

  We need to show that (0 = 1).

  It holds that (0 = 0).
  It holds that (0 = 2).
```

and throws an error stating that the `Expand definition` line needs to be removed in the final proof.
