### PR TITLE
fix: Throw fake syntax error if user-input is read as e.g. "Obtain such a Qed."

### DIFF
--- a/tests/tactics/Induction.v
+++ b/tests/tactics/Induction.v
@@ -52,3 +52,10 @@ Proof.
       intro IHk.
       reflexivity.
 Qed.
+
+(* Test 2: throws error if variable name is 'Qed' 
+    (quick fix for Waterproof editor / Coq lsp)  *)
+Goal forall n : nat, (n = n).
+Proof.
+    Fail We use induction on Qed.
+Abort.

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -109,3 +109,12 @@ Proof.
     pose (H0 eps H1).
     Obtain such an N1.
 Abort.
+
+
+(** Test 9: throws error if variable name is 'Qed' 
+    (quick fix for Waterproof editor / Coq lsp)  *)
+Goal (exists n : nat, n + 1 = n)%nat -> False.
+Proof.
+  intro i.
+  Fail Obtain such Qed.
+Abort.

--- a/theories/Tactics/Induction.v
+++ b/theories/Tactics/Induction.v
@@ -64,7 +64,23 @@ Ltac2 induction_without_hypothesis_naming (x: ident) :=
   end.
 
 
+(* Quick fix for Wateproof editor / Coq lsp, where
+  [We use induction on 
+  
+   Qed.]
+  was interpreted [We use induction on Qed.].
+  Although in Coq [Qed] is acceptable as variable name, it is confusing.
+  Hence we throw an error in the form of a 'Syntax error'.
+
+  TODO: can probably be fixed with binders...
+*)
+Local Ltac2 panic_ident_Qed (i : ident) :=
+  if Ident.equal i @Qed
+    then throw (of_string "Syntax error: variable name expected after 'on'.")
+    else ().  
+
 Ltac2 Notation "We" "use" "induction" "on" x(ident) :=
+  panic_ident_Qed (x);
   panic_if_goal_wrapped ();
   induction_without_hypothesis_naming x.
 

--- a/theories/Tactics/Obtain.v
+++ b/theories/Tactics/Obtain.v
@@ -127,8 +127,23 @@ Ltac2 obtain_according_to (var : ident) (hyp : ident) :=
     [of_string "Statement "; of_constr h; of_string " is not of the form 'there exists ...'."])
   end.
 
+(* Quick fix for Wateproof editor / Coq lsp, where
+  [Obtain such an 
+  
+   Qed.]
+  was interpreted [Obtain such an Qed.].
+  Although in Coq [Qed] is acceptable as variable name, it is confusing.
+  Hence we throw an error in the form of a 'Syntax error'.
+
+  TODO: can probably be fixed with binders...
+*)
+Local Ltac2 panic_ident_Qed (i : ident) :=
+  if Ident.equal i @Qed
+    then throw (of_string "Syntax error: variable name expected after 'such'.")
+    else ().
   
 Ltac2 Notation "Obtain" "such" a(opt("a")) an(opt("an")) var(ident) :=
+  panic_ident_Qed (var);
   panic_if_goal_wrapped ();
   try_out_label var;
   obtain_according_to_last var.


### PR DESCRIPTION
Coq lsp reads the input
```
Obtain such an

Qed.
```
as a single line, `Obtain such an Qed.`
This causes issues in the Waterproof editor: since (presumably) the line with `Qed.` in it does not throw an error, the bar to the side of the proof in the editor colors green, which normally indicates that the proof is complete.

This issue might be fixed when binders are incorporated into the `Obtain`-tactic, but we might wish to keep this check in order to produce non-confusing errors.