### PR TITLE
feat: Tactics for postponing proof of statement.

### DIFF
--- a/tests/tactics/Postpone.v
+++ b/tests/tactics/Postpone.v
@@ -1,0 +1,55 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Message.
+
+Require Import Waterproof.Waterproof.
+Require Import Waterproof.Automation.
+Require Import Waterproof.Tactics.
+
+(** By magic it holds that ....  *)
+
+(** Test 0: old notation still works. *)
+Goal (0 = 0).
+Proof.
+  By I it holds that (True) (H1).
+Abort.
+
+(** Test 1: postpone proof of claim. Claim added to hypotheses, warning raised. *)
+Goal (0 = 0).
+Proof.
+  By magic it holds that (False) (H2).
+  By magic it holds that (0 = 1) (H3).
+Abort.
+
+
+(** By magic we conclude that ...  *)
+
+(** Test 2: old notation still works. *)
+Goal (True).
+Proof.
+  By I we conclude that (True).
+Abort.
+
+(** Test 3: postpone proof of conclusion. Raises warning. *)
+Goal (0 = 1).
+Proof.
+  By magic we conclude that (0 = 1).
+Abort.

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -50,8 +50,12 @@ Local Ltac2 try_out_label (label : ident) :=
 
 (** Attempts to assert that [claim] holds, if succesful [claim] is added to the local
   hypotheses. If [label] is specified [claim] is given [label] as its identifier, otherwise an
-  identifier starting with '_H' is generated. *)
-Local Ltac2 wp_assert (claim : constr) (label : ident option) :=
+  identifier starting with '_H' is generated.
+  
+  Additionally, if argument [postpone] is [true], actually proving the claim is postponed.
+  The claim is asserted and the proof is shelved using an evar.
+  *)
+Local Ltac2 wp_assert (claim : constr) (label : ident option) (postpone : bool):=
   let err_msg (g : constr) := concat_list
     [of_string "Could not verify that "; of_constr g; of_string "."] in
   let id := 
@@ -61,14 +65,29 @@ Local Ltac2 wp_assert (claim : constr) (label : ident option) :=
     end
   in
   let claim := correct_type_by_wrapping claim in
-  match Control.case (fun () =>
-    assert $claim as $id by 
-      (waterprove 5 true Main))
-  with
-  | Val _ => ()
-  | Err (FailedToProve g) => throw (err_msg g)
-  | Err exn => Control.zero exn
-  end.
+  if postpone
+    then
+      (* Assert claim and proof using shelved evar *)
+      (* (using 'admit' would have shown a confusing warning message) *)
+      assert $claim as $id;
+      Control.focus 1 1 (fun () =>
+        let evar_id := Fresh.in_goal @_Hpostpone in
+        ltac1:(id claim |- evar (id : claim)) (Ltac1.of_ident evar_id) (Ltac1.of_constr claim); 
+        let evar := Control.hyp evar_id in 
+        exact $evar
+        );
+      warn (concat_list [of_string "Please come back later to provide an actual proof of ";
+        of_constr claim; of_string "."])
+    else
+      (* Assert claim and attempt to prove automatically *)
+      match Control.case (fun () =>
+        assert $claim as $id by 
+          (waterprove 5 true Main))
+      with
+      | Val _ => ()
+      | Err (FailedToProve g) => throw (err_msg g)
+      | Err exn => Control.zero exn
+      end.
 
 
 (** Attempts to assert that [claim] holds, if succesful [claim] is added to the local
@@ -184,8 +203,27 @@ Local Ltac2 wp_assert_with_unwrap (claim : constr) (label : ident option) :=
     end
   | [|- _] => 
     panic_if_goal_wrapped ();
-    wp_assert claim label
+    wp_assert claim label false
   end.
 
 Ltac2 Notation "It" "holds" "that" claim(constr) label(opt(seq("(", ident, ")")))  :=
   wp_assert_with_unwrap claim label.
+
+
+(** * By magic it holds that ... (...)
+  Asserts a claim and proves it using a shelved evar.
+
+  Arguments:
+    - [label: ident option], optional name for the claim. 
+    - [claim: constr], the actual content of the claim to prove.
+
+    Raises exception:
+    - [[label] is already used], if there is already another hypothesis with identifier [label].
+
+    Raises warning:
+    - [Please come back later to provide an actual proof of [claim].], always.
+*)
+
+Ltac2 Notation "By" "magic" "it" "holds" "that" claim(constr) label(opt(seq("(", ident, ")"))) := 
+  panic_if_goal_wrapped ();
+  wp_assert claim label true.


### PR DESCRIPTION
Add options to postpone proof to 'It holds' and 'We conclude' tactics.
Lines with postponed proof give warnings reminding user that they still need to give an actual proof.

example usage:
```
By magic it holds that (0 = 0).  (* difficult yet true claim *)
By magic it holds that (0 = 1).  (* impossible claim *)
``` 
```
By magic we conclude that (0 = 1).
```
