### PR TITLE
feat: Provide suggestions to users on how to use forall- and exists-statements.

### DIFF
--- a/tests/tactics/Help.v
+++ b/tests/tactics/Help.v
@@ -62,3 +62,70 @@ Goal (forall n : nat, n = n) -> (exists m : nat, m = 0) -> (0 = 1).
   intros.
   Help.
 Abort.
+
+
+
+(** Test advice how to use newly introduced statements. *)
+
+Require Import Waterproof.Tactics.ItHolds.
+
+(** Test 7: It holds that, no label. *)
+Goal False.
+Proof.
+  It holds that (forall n : nat, n = n).
+Abort.
+
+(** Test 8: It holds that, label. *)
+Goal False.
+Proof.
+  It holds that (forall n : nat, n = n) (i).
+Abort.
+
+(** Test 9: By ... it holds that, no label. *)
+Goal False.
+Proof.
+  By I it holds that (forall n : nat, True).
+Abort.
+
+(** Test 10: Since ... it holds that, no label. *)
+Goal False.
+Proof.
+  Since (True) it holds that (forall n : nat, n = n).
+Abort.
+
+
+Require Import Waterproof.Tactics.Assume.
+
+(** Test 11: Assume that, no label. *)
+Goal (forall n : nat, n = n) -> False.
+Proof.
+  Assume that (forall n : nat, n = n).
+Abort.
+
+(** Test 12: Assume that, label. *)
+Goal (forall n : nat, n = n) -> False.
+Proof.
+  Assume that (forall n : nat, n = n) (i).
+Abort.
+
+(** Test 13: Assume negation. *)
+Goal not (forall n : nat, n = n).
+Proof.
+  Assume that (forall n : nat, n = n).
+Abort.
+
+
+Require Import Waterproof.Tactics.Claims.
+
+(** Test 11: We claim that, no label. *)
+Goal False.
+Proof.
+  We claim that (forall n : nat, n = n).
+Abort.
+
+(** Test 12: Assume that, label. *)
+Goal (forall n : nat, n = n) -> False.
+Proof.
+  We claim that (forall n : nat, n = n) (i).
+Abort.
+

--- a/tests/tactics/Help.v
+++ b/tests/tactics/Help.v
@@ -1,0 +1,64 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Option.
+
+Require Import Waterproof.Tactics.Help.
+
+(** Test 0 : Suggest to follow advice in goal if goal is wrapped 
+  or [False] (i.e. prove contradiction). *)
+Goal False.
+  Help.
+Abort.
+
+(** Test 1 : Only suggest to follow advice in goal if goal is wrapped 
+  or [False] (i.e. prove contradiction). *)
+Goal (forall n : nat, n = n) -> False.
+  intros.
+  Help.
+Abort.
+
+(** Test 2 : Suggest to solve directly if goal can be shown automatically. *)
+Goal True.
+  Help.
+Abort.
+
+(** Test 3 : Only suggest to solve directly if goal can be shown automatically. *)
+Goal (forall n : nat, n = n) -> True.
+  intros.
+  Help.
+Abort.
+
+(** Test 4 : Report \forall hypotheses if available. *)
+Goal (forall n : nat, n = n) -> (forall m : nat, m + 1 = m + 1) -> (0 = 1).
+  intros.
+  Help.
+Abort.
+
+(** Test 5 : Report \exists hypotheses if available. *)
+Goal (exists n : nat, n = n) -> (exists m : nat, m + 1 = m + 1) -> (0 = 1).
+  intros.
+  Help.
+Abort.
+
+(** Test 6 : Report \forall and \exists hypotheses if available. *)
+Goal (forall n : nat, n = n) -> (exists m : nat, m = 0) -> (0 = 1).
+  intros.
+  Help.
+Abort.

--- a/theories/Tactics/Assume.v
+++ b/theories/Tactics/Assume.v
@@ -28,6 +28,8 @@ Require Import Util.Init.
 Require Import Util.MessagesToUser.
 Require Import Util.TypeCorrector.
 
+Require Import Waterproof.Tactics.Help.
+
 Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) := 
   concat_list [of_string "Expected assumption of "; of_constr e;
     of_string " instead of "; of_constr t; of_string "."].
@@ -45,28 +47,31 @@ Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) :=
 *)
 Local Ltac2 assume_negation (x : (constr * (ident option)) list) :=
   match x with 
-    | [] => () (* Done. *)
-    | head::tail => match head with
+  | [] => () (* Done. *)
+  | head::tail => 
+      match head with
       | (t, n) => (* Check whether the right negated expression is assumed. *)
-        lazy_match! goal with
+          lazy_match! goal with
           | [ |- not ?u ] => 
-            let t := correct_type_by_wrapping t in
-            match check_constr_equal u t with
+              let t := correct_type_by_wrapping t in
+              match check_constr_equal u t with
               | false => throw (expected_of_type_instead_of_message u t)
               | true  => (* Check whether this was the only assumption made.*)
-                match tail with
+                  match tail with
                   | h::t => throw (of_string "Nothing left to assume after the negated expression.")
                   | [] => (* Assume negation : check whether a name has been given *)
-                    match n with
+                      match n with
                       | None   => let h := Fresh.in_goal @_H in intro $h; change $t in $h
                       | Some n => intro $n; change $t in $n
-                    end
-                end
-            end
+                      end;
+                      (* Print suggestion on how to use new statement. *)
+                      HelpNewHyp.suggest_how_to_use t n
+                  end
+              end
           | [ |- _ ] => Control.zero (Unreachable "")
+          end
       end
-  end
-end.
+  end.
 
 (**  
   Attempts to recursively assume a list of hypotheses.
@@ -83,27 +88,29 @@ end.
 *)
 Local Ltac2 rec process_ident_type_pairs (x : (constr * (ident option)) list) :=
   match x with
-    | head::tail =>
+  | head::tail =>
       match head with
-        | (t, n) => (* Check whether next assumption (i.e. [t]) is that of a negated expression. *)
+      | (t, n) => (* Check whether next assumption (i.e. [t]) is that of a negated expression. *)
           lazy_match! goal with
-            | [ |- not _ ]   => assume_negation x (* If so, switch to different subroutine. *)
-            | [ |- ?u -> _ ] => (* Check whether the domain is a proposition. *)
+          | [ |- not _ ]   => assume_negation x (* If so, switch to different subroutine. *)
+          | [ |- ?u -> _ ] => (* Check whether the domain is a proposition. *)
               let sort_u := get_value_of_hyp u in
               match check_constr_equal sort_u constr:(Prop) with
-                | true => (* Check whether we need variabled of type t. *)
+              | true => (* Check whether we need variabled of type t. *)
                   let t := correct_type_by_wrapping t in
                   match check_constr_equal u t with
-                    | true => (* Check whether a name has been given *)
+                  | true => (* Check whether a name has been given *)
                       match n with
-                        | None   => let h := Fresh.in_goal @_H in intro $h; change $t in $h
-                        | Some n => intro $n; change $t in $n
-                          end
-                    | false => throw (expected_of_type_instead_of_message u t)
+                      | None   => let h := Fresh.in_goal @_H in intro $h; change $t in $h
+                      | Some n => intro $n; change $t in $n
+                      end;
+                      (* Print suggestion on how to use new statement. *)
+                      HelpNewHyp.suggest_how_to_use t n
+                  | false => throw (expected_of_type_instead_of_message u t)
                   end
-                | false => throw (of_string "`Assume ...` cannot be used to construct a map (→). Use [Take] instead.")
+              | false => throw (of_string "`Assume ...` cannot be used to construct a map (→). Use [Take] instead.")
               end
-            | [ |- _ ] => throw (of_string "Tried to assume too many properties.")
+          | [ |- _ ] => throw (of_string "Tried to assume too many properties.")
           end
       end;
 
@@ -115,8 +122,8 @@ Local Ltac2 rec process_ident_type_pairs (x : (constr * (ident option)) list) :=
 
 Local Ltac2 remove_contra_wrapper (wrapped_assumption : constr) (assumption : constr) :=
   match (check_constr_equal wrapped_assumption assumption) with
-    | true  => apply (ByContradiction.wrap $wrapped_assumption)
-    | false => throw (of_string "Wrong assumption specified.")
+  | true  => apply (ByContradiction.wrap $wrapped_assumption)
+  | false => throw (of_string "Wrong assumption specified.")
   end.
 
 
@@ -126,7 +133,7 @@ Local Ltac2 remove_contra_wrapper (wrapped_assumption : constr) (assumption : co
 Local Ltac2 assume (x : (constr * (ident option)) list) := 
   (* Handle goal wrappers *)
   lazy_match! goal with
-    | [ |- ByContradiction.Wrapper ?a _ ] => 
+  | [ |- ByContradiction.Wrapper ?a _ ] => 
       match x with 
       | head::_ => 
         match head with
@@ -134,13 +141,13 @@ Local Ltac2 assume (x : (constr * (ident option)) list) :=
         end
       | [] => panic_if_goal_wrapped ()
       end
-    | [ |- _ ] => panic_if_goal_wrapped ()
-    end;
+  | [ |- _ ] => panic_if_goal_wrapped ()
+  end;
   (* Make assumption and perform checks on input *)
   lazy_match! goal with
-    | [ |- not _ ]  => assume_negation x
-    | [ |- _ -> _ ] => process_ident_type_pairs x
-    | [ |- _ ] => throw (of_string "`Assume ...` can only be used to prove an implication (⇨) or a negation (¬).")
+  | [ |- not _ ]  => assume_negation x
+  | [ |- _ -> _ ] => process_ident_type_pairs x
+  | [ |- _ ] => throw (of_string "`Assume ...` can only be used to prove an implication (⇨) or a negation (¬).")
   end.
 
 

--- a/theories/Tactics/Claims.v
+++ b/theories/Tactics/Claims.v
@@ -21,6 +21,8 @@ Require Import Ltac2.Ltac2.
 Require Import Util.Constr.
 Require Import Util.Goals.
 
+Require Import Waterproof.Tactics.Help.
+
 Local Ltac2 my_assert (t:constr) (id:ident option) := 
   (* Fixed by fixing the ltac2_assert *)
   match id with
@@ -32,4 +34,6 @@ Local Ltac2 my_assert (t:constr) (id:ident option) :=
 
 Ltac2 Notation "We" "claim" "that" t(constr) id(opt(seq("(", ident, ")"))) :=
   panic_if_goal_wrapped ();
+  (* Print suggestion on how to use new statement (after it is proven). *)
+  HelpNewHyp.suggest_how_to_use_after_proof t id;
   my_assert t id.

--- a/theories/Tactics/Help.v
+++ b/theories/Tactics/Help.v
@@ -28,35 +28,50 @@ Require Import Util.MessagesToUser.
 
 Require Import Waterprove.
 
-Ltac2 Type exn ::= [ Inner ].
 
-Local Ltac2 create_forall_message (v_type: constr) :=
-  concat_list [of_string "The goal is to show a ‘for all’-statement (∀).
-Introduce an arbitrary variable of type "; of_constr v_type; of_string ".
-Use ‘Take ... : (...).’."].
-
-Local Ltac2 create_implication_message (premise: constr) :=
+Local Ltac2 goal_impl_msg (premise: constr) :=
   concat_list [of_string "The goal is to show an implication (⇒).
-Assume the premise "; of_constr premise; of_string ".
-Use ‘Assume that (...).’."].
+Assume the premise "; of_constr premise; of_string ", use
+    Assume that (...)."].
 
-Local Ltac2 create_function_message (premise: constr) :=
+Local Ltac2 goal_func_msg (var_type: constr) :=
   concat_list [of_string "The goal is to construct a map (⇒).
-Introduce an arbitrary variable of type "; of_constr premise; of_string ".
-Use ‘Take ... : (...).’."].
+Introduce an arbitrary variable of type "; of_constr var_type; of_string ", use
+    Take ... : (...)."].
 
-Local Ltac2 create_exists_message (premise: constr) :=
+Local Ltac2 goal_forall_msg (var_type: constr) :=
+  concat_list [of_string "The goal is to show a ‘for all’-statement (∀).
+Introduce an arbitrary variable of type "; of_constr var_type; of_string ", use
+    Take ... : (...)."].
+
+Local Ltac2 goal_exists_msg (var_type: constr) :=
   concat_list [of_string "The goal is to show a ‘there exists’-statement (∃).
-Choose a specific variable of type "; of_constr premise; of_string ".
-Use ‘Choose ... := (...).’ or ‘Choose (...).’."].
+Choose a specific variable of type "; of_constr var_type; of_string ", use
+    Choose ... := (...)."].
 
-Local Ltac2 create_goal_wrapped_message () := of_string "Follow the advice in the goal window.".
+Local Ltac2 goal_and_msg () := of_string
+  "The goal is to show a conjunction (∧).
+Show both statements, use
+    We show both statements.".
 
-Local Ltac2 create_not_message (negated_type : constr) := 
+Local Ltac2 goal_or_msg () := of_string
+"The goal is to show a disjunction (∨).
+It suffices to show one of the statements, use
+    It suffices to show that (...).".
+
+Local Ltac2 goal_neg_msg (negated_type : constr) := 
   concat_list [of_string "The goal is to show a negation (¬).
-Assume that the negated expression "; of_constr negated_type; 
-of_string " holds, then show a contradiction.
-Use ‘Assume that (...).’ to do the first step."].
+Assume that the negated expression "; of_constr negated_type; of_string ", use
+    Assume that (...)."].
+
+Local Ltac2 goal_directly () := of_string
+  "The goal can be shown immediately, use
+    We conclude that (...).".
+
+Local Ltac2 goal_no_hint ():= of_string
+  "No direct hint available.
+Does the goal contain a definition that can be expanded?".
+
 
 (**
   Auxilliary tactic that checks if goal can be shown with automation
@@ -68,72 +83,96 @@ Local Ltac2 solvable_by_core_auto () :=
   Control.focus 1 1 (fun () => waterprove 5 true Main);
   clear $temp_id.
 
-(**
-  Give a hint indicating a potential step to proving a given proposition [g].
 
-  Arguments:
-    - [g : constr], should be a [Prop], namely the goal to provide hints for.
-    
-  Returns:
-    - [message], message containing a hint.
-  
-  Raises exceptions:
-    - [GoalHintError], if no hint is available for [g].
-*)
-Ltac2 goal_to_hint (g:constr) :=
-  (* The order matters. If the ∀ case is above the ⇒, then implications will fire the ∀ case instead.*)
-  lazy_match! g with
-    | ?a -> ?b  => 
-      let sort_a := get_value_of_hyp a in
-      match check_constr_equal sort_a constr:(Prop) with
-        | true  => create_implication_message a
-        | false => create_function_message a
-      end
-    | forall v:?v_type, _ => create_forall_message v_type
-    | exists v:?v_type, _ => create_exists_message v_type
-    | _ /\ _ => of_string
-"The goal is to show a conjunction (∧).
-Show both statements, use ‘We show both statements.’"
-    | _ \/ _ => of_string
-"The goal is to show a disjunction (∨).
-Show one of the statements, use ‘It suffices to show that (...).’ with the dots replaced with the statement you decide to show."
-    | Case.Wrapper _ _                => create_goal_wrapped_message ()
-    | NaturalInduction.Base.Wrapper _ => create_goal_wrapped_message ()
-    | NaturalInduction.Step.Wrapper _ => create_goal_wrapped_message ()
-    | StateGoal.Wrapper _             => create_goal_wrapped_message ()
-    | ByContradiction.Wrapper _ _     => create_goal_wrapped_message ()
-    | not ?g => create_not_message g
-    | False  => create_goal_wrapped_message ()
-    | _ => 
-      match Control.case (solvable_by_core_auto) with
-        | Val _ => of_string "The goal can be shown immediately, use ‘We conclude that (...).’."
-        | Err exn => Control.zero Inner
-      end
+Local Ltac2 need_to_follow_advice () : bool := 
+  let gl := Control.goal () in
+  lazy_match! gl with 
+  | Case.Wrapper _ _                => true
+  | NaturalInduction.Base.Wrapper _ => true
+  | NaturalInduction.Step.Wrapper _ => true
+  | StateGoal.Wrapper _             => true
+  | StateHyp.Wrapper _ _ _          => true
+  | ByContradiction.Wrapper _ _     => true
+  | False                           => true
+  | _ => false
   end.
 
-(**
-  Print a hint indicating a potential step to proving the current goal (if the goal is a ∀, ⇒ or ∃ proposition).
-  When no hint is available, print "No hint available".
-
-  Arguments:
-    - [g: constr option], optional goal to generate hint for. If [None] is given, then uses currently active goal.
-*)
-Ltac2 print_goal_hint (g: constr option) :=
-  let g' := 
-    match g with
-      | None => Control.goal ()
-      | Some y => y
+Local Ltac2 goal_hint () : message :=
+  let gl := Control.goal () in
+  lazy_match! gl with
+  | ?a -> ?b  => 
+    let sort_a := get_value_of_hyp a in
+    match check_constr_equal sort_a constr:(Prop) with
+      | true            => goal_impl_msg a
+      | false           => goal_func_msg a
     end
-  in let f () := goal_to_hint g' in
-  match Control.case f with
-    | Val mess => 
-      match mess with
-        | (mess, _) => print mess
-      end
-    | Err exn => print (of_string "No hint available for this goal.")
+  | forall v:?v_type, _ => goal_forall_msg v_type
+  | exists v:?v_type, _ => goal_exists_msg v_type
+  | _ /\ _              => goal_and_msg ()
+  | _ \/ _              => goal_or_msg ()
+  | not ?g              => goal_neg_msg g
+  | _                   => goal_no_hint ()
   end.
+
+Local Ltac2 forall_filter (x : constr) : bool :=
+  lazy_match! x with
+  | ?a -> ?b     => false
+  | forall _, _  => true
+  | _            => false
+  end.
+
+Local Ltac2 exists_filter (x : constr) : bool :=
+  lazy_match! x with
+  | exists _, _  => true
+  | _            => false
+  end.
+
+Local Ltac2 is_empty (ls : 'a list) :=
+  match ls with
+  | _::_ => false
+  | []   => true
+  end.
+
+
+Ltac2 print_hints () :=
+  
+  if (need_to_follow_advice ())
+    then (print (of_string "Follow the advice in the goal window."))
+    
+    else
+      match Control.case (solvable_by_core_auto) with
+      | Val _           => print (goal_directly ())
+      | Err exn         =>
+
+        print (goal_hint ());
+
+        let hyps := List.map (fun (i, x, t) => t) (Control.hyps ()) in
+        let forall_hyps := List.filter (forall_filter) hyps in
+        let exists_hyps := List.filter (exists_filter) hyps in
+
+        if (is_empty forall_hyps)
+          then ()
+          else (
+            print(of_string "");
+            print(of_string "To use one of the ‘for all’-statements (∀)");
+            List.fold_left (fun _ h => print (concat (of_string "    ") (of_constr h))) forall_hyps ();
+            print(of_string "use");
+            print(of_string "    Use ... := (...) in (...).")
+          );
+        
+        if (is_empty exists_hyps)
+          then ()
+          else (
+            print(of_string "");
+            print(of_string "To use one of the ‘there exists’-statements (∃)");
+            List.fold_left (fun _ h => print (concat (of_string "    ") (of_constr h))) exists_hyps ();
+            print(of_string "use");
+            print(of_string "    Obtain ... according to (...).")
+          )
+      end.
+
 
 (** * Help tactic
     Tries to give a hint how to proceed proving the current goal.
 *)
-Ltac2 Notation "Help" := print_goal_hint None.
+Ltac2 Notation "Help" := print_hints ().

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -30,6 +30,8 @@ Require Import Util.MessagesToUser.
 Require Import Util.TypeCorrector.
 Require Import Waterprove.
 
+Require Import Waterproof.Tactics.Help.
+
 
 (** Tries to make the assertion [True] with label [label].
   Throws an error if this fails, i.e. if the label is already used
@@ -68,7 +70,9 @@ Local Ltac2 wp_assert (claim : constr) (label : ident option) :=
   | Val _ => ()
   | Err (FailedToProve g) => throw (err_msg g)
   | Err exn => Control.zero exn
-  end.
+  end;
+  (* Print suggestion on how to use new statement. *)
+  HelpNewHyp.suggest_how_to_use claim label.
 
 
 (** Attempts to assert that [claim] holds, if succesful [claim] is added to the local
@@ -98,13 +102,17 @@ Local Ltac2 core_wp_assert_by (claim : constr) (label : ident option) (xtr_lemma
 (** Adaptation of [core_wp_assert_by] that turns the [FailedToUse] errors 
   which might be thrown into user readable errors. *)
 Local Ltac2 wp_assert_by (claim : constr) (label : ident option) (xtr_lemma : constr) :=
-  wrapper_core_by_tactic (core_wp_assert_by claim label) xtr_lemma.
+  wrapper_core_by_tactic (core_wp_assert_by claim label) xtr_lemma;
+  (* Print suggestion on how to use new statement. *)
+  HelpNewHyp.suggest_how_to_use claim label.
 
 (** Adaptation of [core_wp_assert_by] that allows user to use mathematical statements themselves
   instead of references to them as extra information for the automation system.
   Uses the code in [Since.v]. *)
 Local Ltac2 wp_assert_since (claim : constr) (label : ident option) (xtr_claim : constr) :=
-  since_framework (core_wp_assert_by claim label) xtr_claim.
+  since_framework (core_wp_assert_by claim label) xtr_claim;
+  (* Print suggestion on how to use new statement. *)
+  HelpNewHyp.suggest_how_to_use claim label.
 
 (**
   Removes a [StateHyp.Wrapper] wrapper from the goal.


### PR DESCRIPTION
### `Help.` tactic

input:
```
Goal (forall n : nat, n = n) -> (exists m : nat, m = 0) -> (0 = 1).    (* difficult goal *)
  intros.
  Help.
Abort.
```
results in printed message:
```
No direct hint available.
Does the goal contain a definition that can be expanded?

To use one of the ‘for all’-statements (∀)
	(forall n : nat, n = n)
use
	Use ... := (...) in (...).

To use one of the ‘there exists’-statements (∃)
	(exists m : nat, m = 0)
use
	Obtain ... according to (...).
```

### Suggestion for new hypothesis
```
It holds that (forall n : nat, n = n).
```
results in printed message
```
To use (forall n : nat, n = n), use
	Use ... := (...) in (...).
``` 

_Note:_ these suggestions do result in a lot of printed messages during library compilation. 
