### PR TITLE
Specialize blank

### DIFF
--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -76,6 +76,7 @@ theories/Tactics/Unfold.v
 
 theories/Util/Assertions.v
 theories/Util/Constr.v
+theories/Util/Evars.v
 theories/Util/Goals.v
 theories/Util/Hypothesis.v
 theories/Util/Init.v

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -144,6 +144,9 @@ tests/tactics/Specialize.v
 tests/tactics/Take.v
 tests/tactics/ToShow.v
 tests/tactics/Unfold.v
+
+## Util
+tests/util/Evars.v
 tests/util/MessagesToUser.v
 
 ## Libs

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -25,6 +25,8 @@ src/wp_auto.ml
 src/wp_auto.mli
 src/wp_eauto.ml
 src/wp_eauto.mli
+src/wp_evars.ml
+src/wp_evars.mli
 src/wp_rewrite.ml
 src/wp_rewrite.mli
 src/databases.mlg

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -246,12 +246,12 @@ let () =
       warn input >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
-  define1 "make_evar_from_constr_external" string @@
+  define1 "refine_goal_with_evar_external" string @@
     fun input -> refine_goal_with_evar input >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
-  define1 "evar_list_from_term_external" constr @@
+  define1 "blank_evars_in_term_external" constr @@
     fun term ->
-      evar_list_from_term term >>= 
+      blank_evars_in_term term >>=
       fun evars -> tclUNIT @@ (of_list of_evar evars)
 }

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -23,16 +23,11 @@ DECLARE PLUGIN "coq-waterproof.plugin"
 module Tac2ffi = Ltac2_plugin.Tac2ffi
 module Tac2env = Ltac2_plugin.Tac2env
 module Tac2expr = Ltac2_plugin.Tac2expr
-module Tac2entries = Ltac2_plugin.Tac2entries
 
 open Proofview
 open Proofview.Notations
 open Util
-open Names
-open Genarg
-open Tac2env
 open Tac2expr
-open Tac2entries.Pltac
 open Tac2ffi
 
 open Exceptions

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -23,15 +23,22 @@ DECLARE PLUGIN "coq-waterproof.plugin"
 module Tac2ffi = Ltac2_plugin.Tac2ffi
 module Tac2env = Ltac2_plugin.Tac2env
 module Tac2expr = Ltac2_plugin.Tac2expr
+module Tac2entries = Ltac2_plugin.Tac2entries
 
 open Proofview
 open Proofview.Notations
+open Util
+open Names
+open Genarg
+open Tac2env
 open Tac2expr
+open Tac2entries.Pltac
 open Tac2ffi
 
 open Exceptions
 open Hint_dataset_declarations
 open Waterprove
+open Wp_evars
 
 let waterproof_version : string = "2.1.1+8.17"
 }
@@ -229,12 +236,9 @@ let () =
       end >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
-  define1 "warn_external" pp @@ 
-    fun input ->
-      warn input >>= fun () -> tclUNIT @@ of_unit ()
-
-let () =
   define1 "throw_external" pp @@
     fun input ->
       err input >>= fun () -> tclUNIT @@ of_unit ()
+
+
 }

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -240,5 +240,18 @@ let () =
     fun input ->
       err input >>= fun () -> tclUNIT @@ of_unit ()
 
+let () =
+  define1 "warn_external" pp @@ 
+    fun input ->
+      warn input >>= fun () -> tclUNIT @@ of_unit ()
 
+let () =
+  define1 "make_evar_from_constr_external" string @@
+    fun input -> refine_goal_with_evar input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
+  define1 "evar_list_from_term_external" constr @@
+    fun term ->
+      evar_list_from_term term >>= 
+      fun evars -> tclUNIT @@ (of_list of_evar evars)
 }

--- a/src/waterproof.mlpack
+++ b/src/waterproof.mlpack
@@ -6,6 +6,7 @@ Hint_dataset
 Wp_rewrite
 Wp_auto
 Wp_eauto
+Wp_evars
 Waterprove
 Databases
 G_waterproof

--- a/src/wp_evars.ml
+++ b/src/wp_evars.ml
@@ -1,0 +1,253 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Ltac2_plugin.Tac2ffi
+open Ltac2_plugin.Tac2env
+open Ltac2_plugin.Tac2expr
+open Ltac2_plugin.Tac2entries
+
+open Pp
+open Proofview
+open Proofview.Notations
+open Util
+open Names
+open Genarg
+
+open Exceptions
+open Hint_dataset_declarations
+open Waterprove
+
+(** Creates a name used to define the function interface *)
+let pname (s: string): ml_tactic_name = { mltac_plugin = "coq-core.plugins.coq-waterproof"; mltac_tactic = s }
+
+(** Wrapper around {! Tac2env.define_primitive} to make easier the primitive definition *)
+let define_primitive (name: string) (arity: 'a arity) (f: 'a) : unit =
+  define_primitive (pname name) (mk_closure arity f)
+
+(** 
+  Defines a function of arity 0 (that only take a [unit] as an argument)
+
+  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: unit := "coq-waterproof" "<name>".]
+*)
+let define0 (name: string) (f: valexpr tactic): unit = define_primitive name arity_one (fun _ -> f)
+
+(** 
+  Defines a function of arity 1 (that only take one argument)
+
+  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: <type> -> unit := "coq-waterproof" "<name>".]
+*)
+let define1 (name: string) (r0: 'a repr) (f: 'a -> valexpr tactic): unit =
+  define_primitive name arity_one begin fun x -> f (repr_to r0 x) end
+
+(** 
+  Defines a function of arity 2 of the same way than {! define1}
+*)
+let define2 (name: string) (r0: 'a repr) (r1: 'b repr) (f: 'a -> 'b -> valexpr tactic): unit =
+  define_primitive name (arity_suc arity_one) @@ fun x y -> f (repr_to r0 x) (repr_to r1 y)
+
+(** 
+  Defines a function of arity 3 of the same way than {! define1}
+*)
+let define3 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (f: 'a -> 'b -> 'c -> valexpr tactic): unit =
+  define_primitive name (arity_suc (arity_suc arity_one)) @@ fun x y z -> f (repr_to r0 x) (repr_to r1 y) (repr_to r2 z)
+
+(** 
+  Defines a function of arity 4 of the same way than {! define1}
+*)
+let define4 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (f: 'a -> 'b -> 'c -> 'd -> valexpr tactic): unit =
+  define_primitive name (arity_suc (arity_suc (arity_suc arity_one))) @@
+  fun x0 x1 x2 x3 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3)
+
+(** 
+  Defines a function of arity 5 of the same way than {! define1}
+*)
+let define5 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> valexpr tactic): unit =
+  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))) @@
+  fun x0 x1 x2 x3 x4 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4)
+
+(** 
+  Defines a function of arity 6 of the same way than {! define1}
+*)
+let define6 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> valexpr tactic): unit =
+  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one))))) @@
+  fun x0 x1 x2 x3 x4 x5 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5)
+
+(** 
+  Defines a function of arity 7 of the same way than {! define1}
+*)
+let define7 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (r6: 'g repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> valexpr tactic): unit =
+  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))))) @@
+  fun x0 x1 x2 x3 x4 x5 x6 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5) (repr_to r6 x6)
+
+(**
+  Utilitary function to cast OCaml types into Ltac2-compatibles types  
+  
+  Comes from [coq/plugins/ltac2/tac2tactics.ml]
+*)
+
+let _ = define0
+let _ = define1
+let _ = define2
+let _ = define3
+let _ = define5
+let _ = define7
+
+let return x = Proofview.tclUNIT x
+
+let wrap_unit f =
+  return
+
+(**
+  Print an overview of the present evars
+*)
+let print_evars : valexpr tactic =
+  tclEVARMAP >>= fun sigma ->
+      tclUNIT @@ of_unit @@
+      if Evd.has_undefined sigma then
+        Feedback.msg_warning (str "there are undefined evars")
+      else
+        Feedback.msg_warning (str "there are no undefined evars")
+
+(** 
+  Should print information about an evar, now only returns 5
+*)
+let print_evar_info (input : Evar.t) : valexpr tactic =
+  tclEVARMAP >>= fun sigma -> Proofview.tclUNIT @@ of_unit @@
+    let (l, k) = (Evd.evar_source (Evd.find sigma input)) in
+    match k with
+    | Evar_kinds.InternalHole -> Feedback.msg_warning (str "The evar is an internal hole")
+    | Evar_kinds.NamedHole _ -> Feedback.msg_warning (str "The evar is a named hole")
+    | _ -> Feedback.msg_warning (str "Not an internal or named hole")
+
+let is_internal_hole (ev_map : Evd.evar_map) (input : Evar.t) : bool =
+  let (l, k) = (Evd.evar_source (Evd.find ev_map input)) in
+  match k with
+  | Evar_kinds.QuestionMark _ -> true
+  | _ -> false
+
+let find_evars_in_term (term : Evd.econstr) :
+  valexpr tactic =
+  tclEVARMAP >>= fun sigma -> Proofview.tclUNIT @@ of_unit @@
+    let evars = Evarutil.undefined_evars_of_term sigma term in
+    Feedback.msg_notice (str "Evars in term: "
+      ++ prlist_with_sep (fun () -> str ", ") Evar.print (Evar.Set.elements evars))
+
+let evar_list_from_term (term : Evd.econstr) :
+  Evar.t list tactic =
+  tclEVARMAP >>= fun sigma -> tclUNIT @@
+    let evars = Evarutil.undefined_evars_of_term sigma term in
+    List.filter (is_internal_hole sigma) (Evar.Set.elements evars)
+
+let make_new_evar_tac (input : Evar.t) : unit tactic =
+  Proofview.Goal.enter begin fun gl ->
+    let gl_sigma = Proofview.Goal.sigma gl in
+    let found_evar = (Evd.find gl_sigma input) in
+    let desired_type = Evd.evar_concl found_evar in
+    Evar_tactics.let_evar (Names.Name.mk_name (Names.Id.of_string "name_of_variable"))
+      desired_type
+  end
+
+let make_evar_from_constr (input : string) : unit tactic =
+  let src = (Loc.tag Evar_kinds.GoalEvar) in
+  Proofview.Goal.enter begin fun gl ->
+    let gl_sigma = Proofview.Goal.sigma gl in
+    let env = Proofview.Goal.env gl in
+    let concl = Proofview.Goal.concl gl in
+    let state_store = Proofview.Goal.state gl in 
+    (* let (l, k) = (Evd.evar_source (Evd.find gl_sigma (Proofview.Goal.goal gl))) in*)
+    Refine.refine ~typecheck:true begin function sigma ->
+      let sigma, t = Evarutil.new_evar ~src ~naming:(Namegen.IntroFresh (Names.Id.of_string input)) env sigma concl in
+      (sigma, t)
+    end
+      (* Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
+      (Tactics.pose_tac (Name.mk_name (Names.Id.of_string "my_variable_name")) t)*)
+  end
+
+let print_number_of_goals : unit tactic =
+  numgoals >>= fun i ->
+    tclUNIT @@ Feedback.msg_notice (str "Number of goals: "++ Pp.int i)
+  (* tclTHEN (make_evar_from_constr "hey")
+  (tclUNIT @@ Feedback.msg_notice (str "tried to find num goals"))*)
+
+let print_number_of_goals_on_shelf : unit tactic =
+  Proofview.Unsafe.tclGETSHELF >>= fun ls ->
+    tclUNIT @@ Feedback.msg_notice (str "Number of goals on shelf: "++ Pp.int (List.length ls))
+
+let focus_on_first : unit tactic =
+  tclFOCUS 1 1 (make_evar_from_constr "hey")
+
+let try_to_get_proofview =
+  Proofview.Goal.enter begin fun gl ->
+    let gl_sigma = Proofview.Goal.sigma gl in
+    let env = Proofview.Goal.env gl in
+    (* for testing purposes only *)
+    let gl_ev = Proofview.Goal.goal gl in
+    let _, pv = Proofview.init gl_sigma [] in
+    let pv = (Proofview.unshelve [gl_ev] pv) in
+    let _, _ , _, _ = Proofview.apply 
+      ~name:(Names.Id.of_string "test_name") ~poly:true env
+      (print_number_of_goals <*> print_number_of_goals_on_shelf
+       <*> focus_on_first) pv in
+    tclUNIT @@ (Feedback.msg_notice (str "try to get proofview"))
+  end
+
+let update_proofview =
+  Proofview_monad.Pv.get  
+
+open Pp
+open Util
+open Proof
+open Proofview_monad
+open Context.Named.Declaration
+
+let () = define0 "print_evars_external" @@ print_evars
+
+let () =
+  define1 "print_evar_info_external" evar print_evar_info
+
+let () =
+  define1 "warn_external" pp @@ 
+    fun input ->
+      warn input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
+  define1 "find_evars_in_term_external" constr find_evars_in_term
+
+let () =
+  define1 "make_new_evar_external" evar @@
+    fun input -> make_new_evar_tac input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
+  define1 "make_evar_from_constr_external" string @@
+    fun input -> make_evar_from_constr input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
+  define0 "try_to_get_proofview_external" @@
+    let f = (fun () -> (tclUNIT @@ of_unit ())) in
+    try_to_get_proofview >>= f
+
+let () =
+  define0 "focus_on_first_external" @@
+    let f = (fun () -> (tclUNIT @@ of_unit ())) in
+    focus_on_first >>= f
+
+let () =
+  define1 "evar_list_from_term_external" constr @@
+    fun term ->
+      evar_list_from_term term >>= 
+      fun evars -> tclUNIT @@ (of_list of_evar evars)

--- a/src/wp_evars.ml
+++ b/src/wp_evars.ml
@@ -33,7 +33,7 @@ let is_blank (ev_map : Evd.evar_map) (ev : Evar.t) : bool =
   A tactic that resturns a list of all evars in a term (= Evd.econstr) that
   were introduced by the user as a blank and have not been resolved yet.
 *)
-let evar_list_from_term (term : Evd.econstr) :
+let blank_evars_in_term (term : Evd.econstr) :
   Evar.t list tactic =
   tclEVARMAP >>= fun sigma -> tclUNIT @@
     let evars = Evarutil.undefined_evars_of_term sigma term in

--- a/src/wp_evars.ml
+++ b/src/wp_evars.ml
@@ -16,238 +16,42 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Ltac2_plugin.Tac2ffi
-open Ltac2_plugin.Tac2env
-open Ltac2_plugin.Tac2expr
-open Ltac2_plugin.Tac2entries
-
-open Pp
 open Proofview
 open Proofview.Notations
-open Util
-open Names
-open Genarg
-
-open Exceptions
-open Hint_dataset_declarations
-open Waterprove
-
-(** Creates a name used to define the function interface *)
-let pname (s: string): ml_tactic_name = { mltac_plugin = "coq-core.plugins.coq-waterproof"; mltac_tactic = s }
-
-(** Wrapper around {! Tac2env.define_primitive} to make easier the primitive definition *)
-let define_primitive (name: string) (arity: 'a arity) (f: 'a) : unit =
-  define_primitive (pname name) (mk_closure arity f)
-
-(** 
-  Defines a function of arity 0 (that only take a [unit] as an argument)
-
-  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: unit := "coq-waterproof" "<name>".]
-*)
-let define0 (name: string) (f: valexpr tactic): unit = define_primitive name arity_one (fun _ -> f)
-
-(** 
-  Defines a function of arity 1 (that only take one argument)
-
-  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: <type> -> unit := "coq-waterproof" "<name>".]
-*)
-let define1 (name: string) (r0: 'a repr) (f: 'a -> valexpr tactic): unit =
-  define_primitive name arity_one begin fun x -> f (repr_to r0 x) end
-
-(** 
-  Defines a function of arity 2 of the same way than {! define1}
-*)
-let define2 (name: string) (r0: 'a repr) (r1: 'b repr) (f: 'a -> 'b -> valexpr tactic): unit =
-  define_primitive name (arity_suc arity_one) @@ fun x y -> f (repr_to r0 x) (repr_to r1 y)
-
-(** 
-  Defines a function of arity 3 of the same way than {! define1}
-*)
-let define3 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (f: 'a -> 'b -> 'c -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc arity_one)) @@ fun x y z -> f (repr_to r0 x) (repr_to r1 y) (repr_to r2 z)
-
-(** 
-  Defines a function of arity 4 of the same way than {! define1}
-*)
-let define4 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (f: 'a -> 'b -> 'c -> 'd -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc arity_one))) @@
-  fun x0 x1 x2 x3 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3)
-
-(** 
-  Defines a function of arity 5 of the same way than {! define1}
-*)
-let define5 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))) @@
-  fun x0 x1 x2 x3 x4 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4)
-
-(** 
-  Defines a function of arity 6 of the same way than {! define1}
-*)
-let define6 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one))))) @@
-  fun x0 x1 x2 x3 x4 x5 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5)
-
-(** 
-  Defines a function of arity 7 of the same way than {! define1}
-*)
-let define7 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (r6: 'g repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))))) @@
-  fun x0 x1 x2 x3 x4 x5 x6 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5) (repr_to r6 x6)
 
 (**
-  Utilitary function to cast OCaml types into Ltac2-compatibles types  
-  
-  Comes from [coq/plugins/ltac2/tac2tactics.ml]
+  Checks whether a given evar is a blank in the evar_map.
 *)
-
-let _ = define0
-let _ = define1
-let _ = define2
-let _ = define3
-let _ = define5
-let _ = define7
-
-let return x = Proofview.tclUNIT x
-
-let wrap_unit f =
-  return
-
-(**
-  Print an overview of the present evars
-*)
-let print_evars : valexpr tactic =
-  tclEVARMAP >>= fun sigma ->
-      tclUNIT @@ of_unit @@
-      if Evd.has_undefined sigma then
-        Feedback.msg_warning (str "there are undefined evars")
-      else
-        Feedback.msg_warning (str "there are no undefined evars")
-
-(** 
-  Should print information about an evar, now only returns 5
-*)
-let print_evar_info (input : Evar.t) : valexpr tactic =
-  tclEVARMAP >>= fun sigma -> Proofview.tclUNIT @@ of_unit @@
-    let (l, k) = (Evd.evar_source (Evd.find sigma input)) in
-    match k with
-    | Evar_kinds.InternalHole -> Feedback.msg_warning (str "The evar is an internal hole")
-    | Evar_kinds.NamedHole _ -> Feedback.msg_warning (str "The evar is a named hole")
-    | _ -> Feedback.msg_warning (str "Not an internal or named hole")
-
-let is_internal_hole (ev_map : Evd.evar_map) (input : Evar.t) : bool =
-  let (l, k) = (Evd.evar_source (Evd.find ev_map input)) in
-  match k with
+let is_blank (ev_map : Evd.evar_map) (ev : Evar.t) : bool =
+  let ev_info = Evd.find ev_map ev in
+  let _, ev_kind = (Evd.evar_source ev_info) in
+  match ev_kind with
   | Evar_kinds.QuestionMark _ -> true
   | _ -> false
 
-let find_evars_in_term (term : Evd.econstr) :
-  valexpr tactic =
-  tclEVARMAP >>= fun sigma -> Proofview.tclUNIT @@ of_unit @@
-    let evars = Evarutil.undefined_evars_of_term sigma term in
-    Feedback.msg_notice (str "Evars in term: "
-      ++ prlist_with_sep (fun () -> str ", ") Evar.print (Evar.Set.elements evars))
-
+(**
+  A tactic that resturns a list of all evars in a term (= Evd.econstr) that
+  were introduced by the user as a blank and have not been resolved yet.
+*)
 let evar_list_from_term (term : Evd.econstr) :
   Evar.t list tactic =
   tclEVARMAP >>= fun sigma -> tclUNIT @@
     let evars = Evarutil.undefined_evars_of_term sigma term in
-    List.filter (is_internal_hole sigma) (Evar.Set.elements evars)
+    List.filter (is_blank sigma) (Evar.Set.elements evars)
 
-let make_new_evar_tac (input : Evar.t) : unit tactic =
-  Proofview.Goal.enter begin fun gl ->
-    let gl_sigma = Proofview.Goal.sigma gl in
-    let found_evar = (Evd.find gl_sigma input) in
-    let desired_type = Evd.evar_concl found_evar in
-    Evar_tactics.let_evar (Names.Name.mk_name (Names.Id.of_string "name_of_variable"))
-      desired_type
-  end
-
-let make_evar_from_constr (input : string) : unit tactic =
+(** 
+  Refines the current goal with just a new named evar, the name of which is
+  freshly generated based on the input string.
+*)
+let refine_goal_with_evar (input : string) : unit tactic =
   let src = (Loc.tag Evar_kinds.GoalEvar) in
   Proofview.Goal.enter begin fun gl ->
-    let gl_sigma = Proofview.Goal.sigma gl in
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in
-    let state_store = Proofview.Goal.state gl in 
-    (* let (l, k) = (Evd.evar_source (Evd.find gl_sigma (Proofview.Goal.goal gl))) in*)
     Refine.refine ~typecheck:true begin function sigma ->
-      let sigma, t = Evarutil.new_evar ~src ~naming:(Namegen.IntroFresh (Names.Id.of_string input)) env sigma concl in
+      let sigma, t = Evarutil.new_evar ~src 
+          ~naming:(Namegen.IntroFresh (Names.Id.of_string input))
+          env sigma concl in
       (sigma, t)
     end
-      (* Tacticals.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-      (Tactics.pose_tac (Name.mk_name (Names.Id.of_string "my_variable_name")) t)*)
   end
-
-let print_number_of_goals : unit tactic =
-  numgoals >>= fun i ->
-    tclUNIT @@ Feedback.msg_notice (str "Number of goals: "++ Pp.int i)
-  (* tclTHEN (make_evar_from_constr "hey")
-  (tclUNIT @@ Feedback.msg_notice (str "tried to find num goals"))*)
-
-let print_number_of_goals_on_shelf : unit tactic =
-  Proofview.Unsafe.tclGETSHELF >>= fun ls ->
-    tclUNIT @@ Feedback.msg_notice (str "Number of goals on shelf: "++ Pp.int (List.length ls))
-
-let focus_on_first : unit tactic =
-  tclFOCUS 1 1 (make_evar_from_constr "hey")
-
-let try_to_get_proofview =
-  Proofview.Goal.enter begin fun gl ->
-    let gl_sigma = Proofview.Goal.sigma gl in
-    let env = Proofview.Goal.env gl in
-    (* for testing purposes only *)
-    let gl_ev = Proofview.Goal.goal gl in
-    let _, pv = Proofview.init gl_sigma [] in
-    let pv = (Proofview.unshelve [gl_ev] pv) in
-    let _, _ , _, _ = Proofview.apply 
-      ~name:(Names.Id.of_string "test_name") ~poly:true env
-      (print_number_of_goals <*> print_number_of_goals_on_shelf
-       <*> focus_on_first) pv in
-    tclUNIT @@ (Feedback.msg_notice (str "try to get proofview"))
-  end
-
-let update_proofview =
-  Proofview_monad.Pv.get  
-
-open Pp
-open Util
-open Proof
-open Proofview_monad
-open Context.Named.Declaration
-
-let () = define0 "print_evars_external" @@ print_evars
-
-let () =
-  define1 "print_evar_info_external" evar print_evar_info
-
-let () =
-  define1 "warn_external" pp @@ 
-    fun input ->
-      warn input >>= fun () -> tclUNIT @@ of_unit ()
-
-let () =
-  define1 "find_evars_in_term_external" constr find_evars_in_term
-
-let () =
-  define1 "make_new_evar_external" evar @@
-    fun input -> make_new_evar_tac input >>= fun () -> tclUNIT @@ of_unit ()
-
-let () =
-  define1 "make_evar_from_constr_external" string @@
-    fun input -> make_evar_from_constr input >>= fun () -> tclUNIT @@ of_unit ()
-
-let () =
-  define0 "try_to_get_proofview_external" @@
-    let f = (fun () -> (tclUNIT @@ of_unit ())) in
-    try_to_get_proofview >>= f
-
-let () =
-  define0 "focus_on_first_external" @@
-    let f = (fun () -> (tclUNIT @@ of_unit ())) in
-    focus_on_first >>= f
-
-let () =
-  define1 "evar_list_from_term_external" constr @@
-    fun term ->
-      evar_list_from_term term >>= 
-      fun evars -> tclUNIT @@ (of_list of_evar evars)

--- a/src/wp_evars.mli
+++ b/src/wp_evars.mli
@@ -1,0 +1,27 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+val print_evars : Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
+
+val print_evar_info : Evar.t -> Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
+
+val find_evars_in_term : Evd.econstr -> Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
+
+val make_new_evar_tac : Evar.t -> unit Proofview.tactic
+
+val make_evar_from_constr : string -> unit Proofview.tactic

--- a/src/wp_evars.mli
+++ b/src/wp_evars.mli
@@ -17,13 +17,15 @@
 (******************************************************************************)
 
 (**
-  Checks whether a given evar is a blank in the evar_map.
+  Checks whether a given evar is a blank (entered by the user with the
+  `_` syntax) in the evar_map.
 *)
 val is_blank : Evd.evar_map -> Evar.t -> bool
 
 (** 
   Refines the current goal with just a new named evar, the name of which is
-  based on the input string.
+  based on the input string. The use of this is to replace unnamed evars with
+  named ones, so that the user can refer to them later.
 *)
 val refine_goal_with_evar : string -> unit Proofview.tactic
 
@@ -31,4 +33,4 @@ val refine_goal_with_evar : string -> unit Proofview.tactic
   A tactic that resturns a list of all evars in a term (= Evd.econstr) that
   were introduced by the user as a blank and have not been resolved yet.
 *)
-val evar_list_from_term : Evd.econstr -> Evar.t list Proofview.tactic
+val blank_evars_in_term : Evd.econstr -> Evar.t list Proofview.tactic

--- a/src/wp_evars.mli
+++ b/src/wp_evars.mli
@@ -16,12 +16,19 @@
 (*                                                                            *)
 (******************************************************************************)
 
-val print_evars : Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
+(**
+  Checks whether a given evar is a blank in the evar_map.
+*)
+val is_blank : Evd.evar_map -> Evar.t -> bool
 
-val print_evar_info : Evar.t -> Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
+(** 
+  Refines the current goal with just a new named evar, the name of which is
+  based on the input string.
+*)
+val refine_goal_with_evar : string -> unit Proofview.tactic
 
-val find_evars_in_term : Evd.econstr -> Ltac2_plugin.Tac2ffi.valexpr Proofview.tactic
-
-val make_new_evar_tac : Evar.t -> unit Proofview.tactic
-
-val make_evar_from_constr : string -> unit Proofview.tactic
+(**
+  A tactic that resturns a list of all evars in a term (= Evd.econstr) that
+  were introduced by the user as a blank and have not been resolved yet.
+*)
+val evar_list_from_term : Evd.econstr -> Evar.t list Proofview.tactic

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -69,3 +69,16 @@ Abort.
 Goal exists n : nat, n + 1 = n + 1.
     Choose n := (?[m]).
 Abort.
+
+(** Test 7: Choose a blank check tha blank was renamed *)
+Goal exists n : nat, n + 1 = n + 1.
+    Choose n := (_).
+    assert (?n = 0).
+Abort.
+
+(** Test 8: Choose a more complicated blank and check that renaming took place, 
+    by reformulating the goal in terms of the new named evars. *)
+Goal exists n : nat, n + 1 = n + 1.
+    Choose n := (_ + _ + _).
+    change (?n + ?n0 + ?n1 + 1 = ?n + ?n0 + ?n1 + 1).
+Abort.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -82,3 +82,17 @@ Goal exists n : nat, n + 1 = n + 1.
     Choose n := (_ + _ + _).
     change (?n + ?n0 + ?n1 + 1 = ?n + ?n0 + ?n1 + 1).
 Abort.
+
+(** Test 9: Choose a blank without specifying the name of the variable *)
+Goal exists n : nat, n + 1 = n + 1.
+  Choose (_).
+  change (?n + 1 = ?n + 1).
+Abort.
+
+(** Test 10: Choose a blank if binder has no name *)
+Goal exists _ : nat, True.
+Proof.
+  Choose (_).
+  (* In this case, the blank evar should be renamed to `x` *)
+  assert (?x = 0). (* This checks if ?x exists and can be referred to. *)
+Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -96,3 +96,60 @@ Use m := 4, n := 3 in (H).
 Fail It holds that (4 = 3). (* as expected :) *)
 It holds that (3 = 4).
 Abort.
+
+(* -------------------------------------------------------------------------- *)
+
+(** Test 8 : use a placeholder as variable name *)
+Goal (forall a b c : nat, a + b + c = 0) -> False.
+Proof.
+intro H.
+Use b := _ in (H).
+It holds that (forall a c : nat, a + ?b + c = 0) (i).
+Abort.
+
+(** Test 8 : use multiple placeholders as variable names *)
+Goal (forall a b c : nat, a + b + c = 0) -> False.
+Proof.
+intro H.
+Use a := _, b := _, c := _ in (H).
+It holds that (?a + ?b + ?c = 0).
+Abort.
+
+(** Test 9 : use named placeholder *)
+Goal (forall a : nat, a = 0) -> False.
+Proof.
+intro H.
+Use a := ?[b] in (H).
+It holds that (?a = 0).
+Abort.
+
+(** Test 10 : use named placeholder, continue with name of placeholder *)
+Goal (forall a : nat, a = 0) -> False.
+Proof.
+intro H.
+Use a := (?[b] : nat) in (H).
+Show Existentials.
+(* TODO: it would be nice if this would pass *)
+Fail It holds that (?b = 0).
+Abort.
+
+(** Test 11 : use an already existing evar *)
+Goal (forall a b : nat, a + b = 0) -> False.
+Proof.
+intro H.
+Use a := _ in (H).
+It holds that (forall b : nat, ?a + b = 0) (i).
+Ltac2 Eval (Constr.has_evar constr:(?a)).
+Use b := ?a in (i).
+Abort.
+
+(** Test 12 : use an already existing named evar *)
+Goal (forall a b : nat, a + b = 0) -> False.
+Proof.
+intro H.
+Use a := ?[b] in (H).
+ltac1:(evar (e : nat)).
+Check ?e.
+It holds that (forall b : nat, ?a + b = 0) (i).
+Use b := ?e in (i).
+Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -115,12 +115,12 @@ Use a := _, b := _, c := _ in (H).
 It holds that (?a + ?b + ?c = 0).
 Abort.
 
-(** Test 9 : use named placeholder *)
+(** Test 9 : use named placeholder: then renaming shouldn't happen *)
 Goal (forall a : nat, a = 0) -> False.
 Proof.
 intro H.
 Use a := ?[b] in (H).
-It holds that (?a = 0).
+Fail It holds that (?a = 0).
 Abort.
 
 (** Test 10 : use named placeholder, continue with name of placeholder *)
@@ -128,28 +128,24 @@ Goal (forall a : nat, a = 0) -> False.
 Proof.
 intro H.
 Use a := (?[b] : nat) in (H).
-Show Existentials.
-(* TODO: it would be nice if this would pass *)
-Fail It holds that (?b = 0).
+It holds that (?b = 0).
 Abort.
 
 (** Test 11 : use an already existing evar *)
 Goal (forall a b : nat, a + b = 0) -> False.
 Proof.
 intro H.
-Use a := _ in (H).
-It holds that (forall b : nat, ?a + b = 0) (i).
-Ltac2 Eval (Constr.has_evar constr:(?a)).
-Use b := ?a in (i).
+ltac1:(evar (e : nat)).
+Use a := (?e + _) in (H).
+It holds that (forall b : nat, ?e + ?a + b = 0) (i).
 Abort.
 
-(** Test 12 : use an already existing named evar *)
+(** Test 12 : use an earlier introduced evar *)
 Goal (forall a b : nat, a + b = 0) -> False.
 Proof.
 intro H.
-Use a := ?[b] in (H).
-ltac1:(evar (e : nat)).
-Check ?e.
+Use a := _ in (H).
 It holds that (forall b : nat, ?a + b = 0) (i).
-Use b := ?e in (i).
+Use b := ?a in (i).
+It holds that (?a + ?a = 0).
 Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -21,6 +21,7 @@ Require Import Ltac2.Message.
 
 Require Import Waterproof.Tactics.
 Require Import Waterproof.Automation.
+Require Import Waterproof.Util.Assertions.
 
 (** Test 0: This should be the expected behavior. *)
 Goal (forall n : nat, n = n) -> True.

--- a/tests/util/Evars.v
+++ b/tests/util/Evars.v
@@ -1,0 +1,11 @@
+Require Import Ltac2.Ltac2.
+Require Import Waterproof.Waterproof.
+Require Import Waterproof.Util.Evars.
+
+Ltac2 Notation "rename_blank_evars_in_term_test" x(open_constr) :=
+  rename_blank_evars_in_term "hi" x.
+
+Goal (forall a b : nat, a + b = 0) -> True.
+Proof.
+rename_blank_evars_in_term_test (_ + _).
+Abort.

--- a/tests/util/Evars.v
+++ b/tests/util/Evars.v
@@ -2,10 +2,44 @@ Require Import Ltac2.Ltac2.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Util.Evars.
 
-Ltac2 Notation "rename_blank_evars_in_term_test" x(open_constr) :=
-  rename_blank_evars_in_term "hi" x.
+(** Test 1 : Test that rename_blank_evars_in_term introduces an evar
+    and names it correctly. *)
+Goal True.
+rename_blank_evars_in_term "a" open_constr:(_).
+ (* Check whether ?a is defined*)
+(fun _ => ()) (Constr.type constr:(?a)).
+(* Indeed, the same statement doesn't work with b *)
+Fail (fun _ => ()) (Constr.type constr:(?b)).
+Abort.
 
-Goal (forall a b : nat, a + b = 0) -> True.
+(** Test 2 : Test that rename_blank_evars_in_term introduces evars deriving their 
+    type from the plus operator, and names them correctly
+*)
+Goal True.
 Proof.
-rename_blank_evars_in_term_test (_ + _).
+rename_blank_evars_in_term "c" open_constr:(_ + _).
+assert (?c + ?c0 = 0). (* Fails if [c] and [c0] are not defined. *)
+Abort.
+
+(** Test 3 : Test with a complicated expression *)
+Goal True.
+Proof.
+rename_blank_evars_in_term "d"
+  open_constr:(forall _ : _, (fun _ _ _ => _) _ _ _ + _ _ = _ _).
+(fun _ => ()) (Constr.type constr:(?d6)).
+(* cannot use ?d now because we're not in the right context *)
+Fail (fun _ => ()) (Constr.type constr:(?d)).
+Abort.
+
+(** Test 4 : Rename the evar corresponding to the current goal *)
+Goal True.
+Proof.
+refine_goal_with_evar "my_goal_name".
+(fun _ => ()) (Constr.type constr:(?my_goal_name)).
+Abort.
+
+(** Test 5 : Rename the evar corresponding to the current goal, and then shelve it *)
+Goal True.
+refine_goal_with_evar "my_goal_name".
+Control.shelve().
 Abort.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -53,16 +53,16 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
       let v := Control.hyp s in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
       match Constr.has_evar t with
-      |  true => 
-        (* TODO: add to the warning the new definition of s *)
-         rename_blank_evars_in_term (Ident.to_string s) t;
-         warn (concat_list [of_string "Please come back to this line later to make a definite choice for "; of_ident s; of_string ". ";
-         of_string "For now you can use that " ;
-         of_ident s; of_string " = "; of_constr t; of_string "."])
+      | true => 
+        rename_blank_evars_in_term (Ident.to_string s) t;
+        
+        warn (concat_list [of_string "Please come back to this line later to make a definite choice for "; of_ident s; of_string ".
+For now you can use that "; of_constr constr:($v = $t); of_string "."])
       | _ => ()
       end;
       exists $v;      
       assert ($w : $v = $t) by reflexivity
+      
     | [ |- _ ] => throw (of_string "`Choose` can only be applied to 'exists' goals.")
   end.
 

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -54,8 +54,11 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
       match Constr.has_evar t with
       |  true => 
+        (* TODO: add to the warning the new definition of s *)
          rename_blank_evars_in_term (Ident.to_string s) t;
-         warn (concat_list [of_string "Please come back to this line later to make a definite choice for "; of_ident s; of_string "."])
+         warn (concat_list [of_string "Please come back to this line later to make a definite choice for "; of_ident s; of_string ". ";
+         of_string "For now you can use that " ;
+         of_ident s; of_string " = "; of_constr t; of_string "."])
       | _ => ()
       end;
       exists $v;      

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -106,25 +106,6 @@ Local Ltac2 wp_assert_by (claim : constr) (label : ident option) (xtr_lemma : co
 Local Ltac2 wp_assert_since (claim : constr) (label : ident option) (xtr_claim : constr) :=
   since_framework (core_wp_assert_by claim label) xtr_claim.
 
-(**
-  Removes a [StateHyp.Wrapper] wrapper from the goal.
-    
-  Arguments: The statement in the specified hypothesis
-    
-  Does: 
-    - Removes the wrapper [StateHyp.Wrapper A G].
-
-  Raises exception:
-    - (fatal) if the wrong hypothesis is specified.
-*)
-Local Ltac2 unwrap_state_hyp (statement : constr) :=
-  lazy_match! goal with
-    | [|- StateHyp.Wrapper ?s _] => 
-         if check_constr_equal s statement
-           then apply (StateHyp.wrap $s)
-           else throw (of_string "Wrong statement specified.")
-    | [|- _] => ()
-  end.
 
 (**
   Attempts to assert a claim and proves it automatically using a specified lemma, 
@@ -148,8 +129,10 @@ Ltac2 Notation "Since" xtr_claim(constr) "it" "holds" "that" claim(constr) label
   panic_if_goal_wrapped ();
   wp_assert_since claim label xtr_claim.
     
+  
 (** * It holds that ... (...)
   Attempts to assert a claim and proves it automatically.
+  Removes [StateHyp.Wrapper] wrapper from the goal (proving claim by automation not necessary).
 
   Arguments:
     - [label: ident option], optional name for the claim. 
@@ -159,8 +142,8 @@ Ltac2 Notation "Since" xtr_claim(constr) "it" "holds" "that" claim(constr) label
     Raises exception:
     - (fatal) if [rwaterprove] fails to prove the claim using the specified lemma.
     - [[label] is already used], if there is already another hypothesis with identifier [label].
+    - (fatal) If goal is wrapped in [StateHyp.Wrapper] and the wrong statement is specified.
 *)
-
 Local Ltac2 wp_assert_with_unwrap (claim : constr) (label : ident option) :=
   (* Try out label first. 
     Code results in wrong error if done inside repeated match.. *)

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -27,27 +27,19 @@ Require Import Util.MessagesToUser.
 Require Import Util.Evars.
 
 (**
-  Convert a (ident * constr) to an (Std.hypothesis * constr) list,
+  Convert a (ident * constr) to a (Std.hypothesis * constr) list,
   by applying Std.NamedHyp to the first arguments of the pairs.
 *)
 Local Ltac2 _ident_to_hyp_list (ls : (ident * constr) list) : (Std.hypothesis * constr) list 
  := List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
 
 (**
-  Get those names from an list of pairs of idents and choice
+  Get those names from a list of pairs of idents and choice
   for those idents, and selects those names where the choice
   has an evar.
 *)
 Local Ltac2 _names_evars (ls : (ident * constr) list) : ident list
  := List.map (fun (i, x) => i) (List.filter (fun (i, x) => Constr.has_evar x) ls).
-
-(**
-  Get those names from an list of pairs of idents and choice
-  for those idents, and selects those names where the choice
-  has an evar.
-*)
-Local Ltac2 _constrs_evars (ls : (ident * constr) list) : constr list
- := List.map (fun (i, x) => x) (List.filter (fun (i, x) => Constr.has_evar x) ls).
 
 (**
   Helper function to make a message of a list of idents,
@@ -90,8 +82,6 @@ Local Ltac2 _binder_name_equal (name : ident) (b : binder) :=
   visible to the end user, and in principle shouldn't occur.
 *)
 Ltac2 Type exn ::= [ Binder_not_found (message) ].
-Ltac2 Type exn ::= [ Hypothesis_not_found (message)].
-Ltac2 Type exn ::= [ Hypothesis_no_definition (message)].
 
 (**
   Helper function to get the type of a binder with a given 
@@ -104,60 +94,6 @@ Local Ltac2 _get_binder_type_from_binder_list (name : ident) (b_list : binder li
   end.
 
 (**
-  Helper function to find the definition of a variable with a given name.
-*)
-Local Ltac2 _find_definition_of_ident (name : ident) : constr :=
-  match! goal with
-  | [i := ?j |- _] =>
-    match Ident.equal i name with
-    | true => j
-    | false => Control.throw (Hypothesis_no_definition (concat_list [of_string "Waterproof internal error: The variable "; of_ident name; of_string " has no definition."]))
-    end
-  |  [|- _] => Control.throw (Hypothesis_not_found (concat_list [of_string "Waterproof internal error: The hypothesis "; of_ident name; of_string " was not found."]))
-  end.
-
-(**
-  Helper function for replace_evars: if the supplied choice
-  contains an evar, replace it by a fresh evar.
-
-  Arguments:
-  - [b_list: binder list], list of binders, should correspond to 
-  the list of binders in the for-all statement
-  - [x : ident * constr], combination of a name of a variable
-    together with a choice for that variable.
-*)
-Local Ltac2 replace_evar (b_list : binder list)  (x : ident * constr) : ident * constr :=
-  let constr_x := (fun (_, y) => y) x in
-  let name_x := (fun (y, _) => y) x in
-  print (of_string "replace evar ");
-  print (of_ident name_x);
-  let fresh_name := Fresh.fresh (Fresh.Free.of_goal ()) name_x in
-  match Constr.has_evar constr_x with
-  | true => 
-      let binder_x := _get_binder_type_from_binder_list name_x b_list in 
-      ltac1:(var_name con |- evar (var_name : con)) (Ltac1.of_ident fresh_name) (Ltac1.of_constr binder_x);
-      let j := _find_definition_of_ident fresh_name in
-      Std.clear [fresh_name];
-      (name_x, j)
-  | false => x
-  end.
-
-(**
-  Replace those variables in the list where the choice contains
-  evars by new evars.
-
-  Arguments:
-  - [xs: (ident * constr) list], list of names for variables together with choices for those variables
-  - [h: constr], the hypothesis, the type of which starts with a for-all statement.
-*)
-Local Ltac2 replace_evars (h : constr) (xs : (ident * constr) list) : (ident * constr) list :=
-  let b_list := get_prod_binders (Constr.type h) in
-  List.map (replace_evar b_list) xs.
-
-Local Ltac2 _replace_evars_aux ((i, c) : ident * constr) () :=
-  rename_blank_evars_in_term (Ident.to_string i) c.
-  
-(**
   Specializes a hypothesis that starts with a for-all statement.
     
   Arguments:
@@ -168,17 +104,11 @@ Local Ltac2 _replace_evars_aux ((i, c) : ident * constr) () :=
     - If the hypothesis [in_hyp] does not start with a for-all statement.
 *)
 Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :=
-  let statement :=
-    print (of_string "evaluate type of blank");
-    eval unfold type_of in (type_of $h) in
+  let statement := eval unfold type_of in (type_of $h) in
   lazy_match! statement with
     | _ -> ?x => (* Exclude matching on functions (naming codomain necessary) *)
       throw (of_string "`Use ... in (*)` only works if (*) starts with a for-all quantifier.")
     | forall _ : _, _ =>
-      (* replace the variables with holes by new evars *)
-      (* TODO: check that the renaming doesn't take place if tactic fails...*)
-      (* let new_var_choice_list := replace_evars h var_choice_list in*)
-      let new_var_choice_list := var_choice_list in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
       (* specialize *)
       Std.specialize (h, Std.ExplicitBindings (_ident_to_hyp_list var_choice_list))
@@ -194,9 +124,10 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
           [of_string "Please come back to this line later to make a definite choice for ";
             _of_idents evars; of_string "."]))
       end;
-      let terms_with_evars := _constrs_evars var_choice_list in
+      (* Rename the blank evars in the terms supplied by the user,
+         in such a way that the base name is derived from the binder name. *)
       List.fold_right (fun (i, c) () =>
-        rename_blank_evars_in_term (Ident.to_string i) c) ()var_choice_list;
+        rename_blank_evars_in_term (Ident.to_string i) c) () var_choice_list;
       (* Wrap the goal *)
       apply (StateHyp.unwrap $type_w $constr_w)
     | _ => throw (of_string "`Use ... in (*)` only works if (*) starts with a for-all quantifier.")
@@ -206,31 +137,14 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
   Specializes a hypothesis that starts with a for-all statement.
     
   Arguments:
-    - [var_choice_list : (ident * constr) list], list of names for variables together with choices for those variables 
+    - [var_choice_list : (ident * constr) list], list of names for variables
+        together with choices for those variables 
     - [in_hyp : ident], name of the hypothesis to specialize.
 
   Raises fatal exceptions:
     - If the hypothesis [in_hyp] does not start with a for-all statement.
 *)
-Ltac2 Notation "Use" s(list1(seq(ident, ":=", open_constr), ",")) "in" "(" in_hyp(constr) ")" :=
+Ltac2 Notation "Use" var_choice_list(list1(seq(ident, ":=", open_constr), ","))
+    "in" "(" in_hyp(constr) ")" :=
   panic_if_goal_wrapped ();
-  wp_specialize s in_hyp.
-
-Ltac2 rec get_all_evars (x : constr) : constr list :=
-  match Constr.Unsafe.kind x with
-  | Constr.Unsafe.Evar e ys => [x]
-  | Constr.Unsafe.Cast a _ b => List.concat [get_all_evars a; get_all_evars b]
-  | Constr.Unsafe.Prod _ a => get_all_evars a
-  | Constr.Unsafe.Lambda _ a => get_all_evars a
-  | Constr.Unsafe.LetIn _ a b => List.concat [get_all_evars a; get_all_evars b]
-  | Constr.Unsafe.App a c => List.concat [get_all_evars a; List.concat (Array.to_list (Array.map get_all_evars c))]
-  (*| Case (case, (constr * Binder.relevance), case_invert, constr, constr array)
-  | Fix (int array, int, binder array, constr array)
-  | CoFix (int, binder array, constr array)
-  | Proj (projection, Binder.relevance, constr)
-  | Uint63 (uint63)
-  | Float (float)
-  | String (pstring)
-  | Array (instance, constr array, constr, constr)*)
-  | _ => []
-  end.
+  wp_specialize var_choice_list in_hyp.

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -95,6 +95,11 @@ Local Ltac2 _get_binder_type_from_binder_list (name : ident) (b_list : binder li
 
 (**
   Specializes a hypothesis that starts with a for-all statement.
+
+  The user supplies names and choices for the bound variables in a given 
+  hypothesis. The tactic then specializes the hypothesis with the given choices. The 
+  choices are allowed to contain clanks. The unnamed holes will be filled in
+  with named evars based on the names of the bound variables.
     
   Arguments:
     - [var_choice_list : (ident * constr) list], list of names for variables together with choices for those variables 

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -18,6 +18,8 @@
 
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
+Local Ltac2 concat_list (ls : message list) : message :=
+  List.fold_right concat (of_string "") ls.
 
 Require Import Util.Init.
 Require Import Util.Goals.
@@ -36,7 +38,23 @@ Require Import Util.MessagesToUser.
 *)
 
 Local Ltac2 _ident_to_hyp_list (ls : (ident * constr) list) : (Std.hypothesis * constr) list 
-:= List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
+ := List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
+
+Local Ltac2 _names_evars (ls : (ident * constr) list) : ident list
+ := List.map (fun (i, x) => i) (List.filter (fun (i, x) => Constr.has_evar x) ls).
+
+Local Ltac2 rec _of_idents (xs : ident list) : message
+ := match List.rev(xs) with
+    | t::[] => of_ident t
+    | t::ls => concat_list [_of_idents (List.rev(ls)); of_string ", "; of_ident t]
+    | [] => of_string ""  (* not used *)
+    end.
+
+Local Ltac2 is_empty (ls : 'a list) : bool
+ := match ls with
+    | _::_ => false
+    | [] => true
+    end.
 
 Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :=
   let statement := eval unfold type_of in (type_of $h) in
@@ -45,12 +63,21 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
       throw (of_string "`Pick ... in (*)` only works if (*) starts with a for-all quantifier.")
     | forall _ : _, _ =>
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
+      (* specialize *)
       Std.specialize (h, Std.ExplicitBindings (_ident_to_hyp_list var_choice_list)) 
         (Some (Std.IntroNaming (Std.IntroIdentifier w))) ;
-      (* specialize $h with ($named_hyp := $choice) as $w; *)
-      (* Wrap the goal *)
+      (* get output *)
       let constr_w := Control.hyp w in
       let type_w := Constr.type constr_w in
+      (* warn user that gap needs to be filled in *)
+      let evars := _names_evars var_choice_list in
+      match is_empty evars with
+      | true => ()
+      | false => warn (concat_list (
+          [of_string "Please come back to this line later to make a definite choice for ";
+            _of_idents evars; of_string "."]))
+      end;
+      (* Wrap the goal *)
       apply (StateHyp.unwrap $type_w $constr_w)
     | _ => throw (of_string "`Pick ... in (*)` only works if (*) starts with a for-all quantifier.")
   end.
@@ -65,5 +92,8 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
   Raises fatal exceptions:
     - If the hypothesis [in_hyp] does not start with a for-all statement.
 *)
-Ltac2 Notation "Use" s(list1(seq(ident, ":=", constr), ",")) "in" "(" in_hyp(constr) ")" :=
+Ltac2 Notation "Use" s(list1(seq(ident, ":=", open_constr), ",")) "in" "(" in_hyp(constr) ")" :=
   wp_specialize s in_hyp.
+
+
+

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -26,6 +26,127 @@ Require Import Util.Goals.
 Require Import Util.MessagesToUser.
 
 
+
+(**
+  Convert a (ident * constr) to an (Std.hypothesis * constr) list,
+  by applying Std.NamedHyp to the first arguments of the pairs.
+*)
+Local Ltac2 _ident_to_hyp_list (ls : (ident * constr) list) : (Std.hypothesis * constr) list 
+ := List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
+
+(**
+  Get those names from an list of pairs of idents and choice
+  for those idents, and selects those names where the choice
+  has an evar.
+*)
+Local Ltac2 _names_evars (ls : (ident * constr) list) : ident list
+ := List.map (fun (i, x) => i) (List.filter (fun (i, x) => Constr.has_evar x) ls).
+
+(**
+  Helper function to make a message of a list of idents,
+  joining them together separated by commas.
+*)
+Local Ltac2 rec _of_idents (xs : ident list) : message
+ := match List.rev(xs) with
+    | t::[] => of_ident t
+    | t::ls => concat_list [_of_idents (List.rev(ls)); of_string ", "; of_ident t]
+    | [] => of_string ""  (* not used *)
+    end.
+
+(**
+  Checks whether a list is empty.
+  TODO: the standard library has this function in a later version, we should use it in later versions.
+*)
+Local Ltac2 is_empty (ls : 'a list) : bool
+ := match ls with
+    | _::_ => false
+    | [] => true
+    end.
+
+(**
+  Get all product binders at the beginning of a for-all type
+*)
+Ltac2 rec get_prod_binders (x : constr) : binder list :=
+  match Constr.Unsafe.kind x with
+  | Constr.Unsafe.Prod a y => a :: get_prod_binders y
+  | _ => []
+  end.
+
+Local Ltac2 _binder_name_equal (name : ident) (b : binder) :=
+  match Constr.Binder.name b with
+  | None => false
+  | Some binder_name => Ident.equal name binder_name
+  end.
+
+(**
+  Exceptions for internal use, they should not be
+  visible to the end user, and in principle shouldn't occur.
+*)
+Ltac2 Type exn ::= [ Binder_not_found (message) ].
+Ltac2 Type exn ::= [ Hypothesis_not_found (message)].
+Ltac2 Type exn ::= [ Hypothesis_no_definition (message)].
+
+(**
+  Helper function to get the type of a binder with a given 
+  name from a list of binders.
+*)
+Local Ltac2 _get_binder_type_from_binder_list (name : ident) (b_list : binder list) : constr :=
+  match List.find_opt (_binder_name_equal name) b_list with
+  | None => Control.throw (Binder_not_found (concat_list [of_string "The variable "; of_ident name; of_string " was not found."]))
+  | Some b => Constr.Binder.type b
+  end.
+
+(**
+  Helper function to find the definition of a variable with a given name.
+*)
+Local Ltac2 _find_definition_of_ident (name : ident) : constr :=
+  match! goal with
+  | [i := ?j |- _] =>
+    match Ident.equal i name with
+    | true => j
+    | false => Control.throw (Hypothesis_no_definition (concat_list [of_string "Waterproof internal error: The variable "; of_ident name; of_string " has no definition."]))
+    end
+  |  [|- _] => Control.throw (Hypothesis_not_found (concat_list [of_string "Waterproof internal error: The hypothesis "; of_ident name; of_string " was not found."]))
+  end.
+
+(**
+  Helper function for replace_evars: if the supplied choice
+  contains an evar, replace it by a fresh evar.
+
+  Arguments:
+  - [b_list: binder list], list of binders, should correspond to 
+  the list of binders in the for-all statement
+  - [x : ident * constr], combination of a name of a variable
+    together with a choice for that variable.
+*)
+Local Ltac2 replace_evar (b_list : binder list)  (x : ident * constr) : ident * constr :=
+  let constr_x := (fun (_, y) => y) x in
+  let name_x := (fun (y, _) => y) x in
+  print (of_string "replace evar ");
+  print (of_ident name_x);
+  let fresh_name := Fresh.fresh (Fresh.Free.of_goal ()) name_x in
+  match Constr.has_evar constr_x with
+  | true => 
+      let binder_x := _get_binder_type_from_binder_list name_x b_list in 
+      ltac1:(var_name con |- evar (var_name : con)) (Ltac1.of_ident fresh_name) (Ltac1.of_constr binder_x);
+      let j := _find_definition_of_ident fresh_name in
+      Std.clear [fresh_name];
+      (name_x, j)
+  | false => x
+  end.
+
+(**
+  Replace those variables in the list where the choice contains
+  evars by new evars.
+
+  Arguments:
+  - [xs: (ident * constr) list], list of names for variables together with choices for those variables
+  - [h: constr], the hypothesis, the type of which starts with a for-all statement.
+*)
+Local Ltac2 replace_evars (h : constr) (xs : (ident * constr) list) : (ident * constr) list :=
+  let b_list := get_prod_binders (Constr.type h) in
+  List.map (replace_evar b_list) xs.
+
 (**
   Specializes a hypothesis that starts with a for-all statement.
     
@@ -36,40 +157,25 @@ Require Import Util.MessagesToUser.
   Raises fatal exceptions:
     - If the hypothesis [in_hyp] does not start with a for-all statement.
 *)
-
-Local Ltac2 _ident_to_hyp_list (ls : (ident * constr) list) : (Std.hypothesis * constr) list 
- := List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
-
-Local Ltac2 _names_evars (ls : (ident * constr) list) : ident list
- := List.map (fun (i, x) => i) (List.filter (fun (i, x) => Constr.has_evar x) ls).
-
-Local Ltac2 rec _of_idents (xs : ident list) : message
- := match List.rev(xs) with
-    | t::[] => of_ident t
-    | t::ls => concat_list [_of_idents (List.rev(ls)); of_string ", "; of_ident t]
-    | [] => of_string ""  (* not used *)
-    end.
-
-Local Ltac2 is_empty (ls : 'a list) : bool
- := match ls with
-    | _::_ => false
-    | [] => true
-    end.
-
 Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :=
-  let statement := eval unfold type_of in (type_of $h) in
+  let statement :=
+    print (of_string "evaluate type of blank");
+    eval unfold type_of in (type_of $h) in
   lazy_match! statement with
     | _ -> ?x => (* Exclude matching on functions (naming codomain necessary) *)
-      throw (of_string "`Pick ... in (*)` only works if (*) starts with a for-all quantifier.")
+      throw (of_string "`Use ... in (*)` only works if (*) starts with a for-all quantifier.")
     | forall _ : _, _ =>
+      (* replace the variables with holes by new evars *)
+      (* TODO: check that the renaming doesn't take place if tactic fails...*)
+      let new_var_choice_list := replace_evars h var_choice_list in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
       (* specialize *)
-      Std.specialize (h, Std.ExplicitBindings (_ident_to_hyp_list var_choice_list)) 
+      Std.specialize (h, Std.ExplicitBindings (_ident_to_hyp_list new_var_choice_list))
         (Some (Std.IntroNaming (Std.IntroIdentifier w))) ;
       (* get output *)
       let constr_w := Control.hyp w in
-      let type_w := Constr.type constr_w in
-      (* warn user that gap needs to be filled in *)
+      let type_w := Constr.type constr_w in      
+      (* warn user that gaps need to be filled in *)
       let evars := _names_evars var_choice_list in
       match is_empty evars with
       | true => ()
@@ -79,7 +185,7 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
       end;
       (* Wrap the goal *)
       apply (StateHyp.unwrap $type_w $constr_w)
-    | _ => throw (of_string "`Pick ... in (*)` only works if (*) starts with a for-all quantifier.")
+    | _ => throw (of_string "`Use ... in (*)` only works if (*) starts with a for-all quantifier.")
   end.
 
 (**
@@ -93,7 +199,24 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
     - If the hypothesis [in_hyp] does not start with a for-all statement.
 *)
 Ltac2 Notation "Use" s(list1(seq(ident, ":=", open_constr), ",")) "in" "(" in_hyp(constr) ")" :=
+  panic_if_goal_wrapped ();
   wp_specialize s in_hyp.
 
-
-
+Ltac2 rec get_all_evars (x : constr) : constr list :=
+  match Constr.Unsafe.kind x with
+  | Constr.Unsafe.Evar e ys => [x]
+  | Constr.Unsafe.Cast a _ b => List.concat [get_all_evars a; get_all_evars b]
+  | Constr.Unsafe.Prod _ a => get_all_evars a
+  | Constr.Unsafe.Lambda _ a => get_all_evars a
+  | Constr.Unsafe.LetIn _ a b => List.concat [get_all_evars a; get_all_evars b]
+  | Constr.Unsafe.App a c => List.concat [get_all_evars a; List.concat (Array.to_list (Array.map get_all_evars c))]
+  (*| Case (case, (constr * Binder.relevance), case_invert, constr, constr array)
+  | Fix (int array, int, binder array, constr array)
+  | CoFix (int, binder array, constr array)
+  | Proj (projection, Binder.relevance, constr)
+  | Uint63 (uint63)
+  | Float (float)
+  | String (pstring)
+  | Array (instance, constr array, constr, constr)*)
+  | _ => []
+  end.

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -28,8 +28,7 @@ Require Import Util.MessagesToUser.
   Specializes a hypothesis that starts with a for-all statement.
     
   Arguments:
-    - [s : ident], name of the variable to choose
-    - [choice : constr], choice for the variable
+    - [var_choice_list : (ident * constr) list], list of names for variables together with choices for those variables 
     - [in_hyp : ident], name of the hypothesis to specialize.
 
   Raises fatal exceptions:
@@ -40,10 +39,7 @@ Local Ltac2 _ident_to_hyp_list (ls : (ident * constr) list) : (Std.hypothesis * 
 := List.map (fun (i, x) => (Std.NamedHyp i, x)) ls.
 
 Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :=
-  (* let h := Control.hyp in_hyp in *)
-  (* let named_hyp := Std.NamedHyp s in *)
   let statement := eval unfold type_of in (type_of $h) in
-  (* let specialized_statement := eval unfold type_of in (type_of ($h $choice)) in *)
   lazy_match! statement with
     | _ -> ?x => (* Exclude matching on functions (naming codomain necessary) *)
       throw (of_string "`Pick ... in (*)` only works if (*) starts with a for-all quantifier.")
@@ -63,8 +59,7 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
   Specializes a hypothesis that starts with a for-all statement.
     
   Arguments:
-    - [s : ident], name of the variable to choose
-    - [choice : constr], choice for the variable
+    - [var_choice_list : (ident * constr) list], list of names for variables together with choices for those variables 
     - [in_hyp : ident], name of the hypothesis to specialize.
 
   Raises fatal exceptions:

--- a/theories/Util/Evars.v
+++ b/theories/Util/Evars.v
@@ -20,12 +20,12 @@ Require Export Ltac2.Ltac2.
 
 Require Import Waterproof.Waterproof.
 
-Ltac2 @ external make_evar_from_constr : string -> unit := "coq-waterproof" "make_evar_from_constr_external".
+Ltac2 @ external refine_goal_with_evar : string -> unit := "coq-waterproof" "refine_goal_with_evar_external".
 
-Ltac2 @ external get_evar_list_in_term : constr -> evar list := "coq-waterproof" "evar_list_from_term_external".
+Ltac2 @ external blank_evars_in_term : constr -> evar list := "coq-waterproof" "blank_evars_in_term_external".
 
 Ltac2 rename_blank_evars_in_term (base_name : string) (x : constr) :=
-  let evars := get_evar_list_in_term x in
+  let evars := blank_evars_in_term x in
   let m := List.length evars in
   List.fold_left (fun _ ev => Control.new_goal ev) (evars) ();
-  Control.focus 2 (Int.add m 1) (fun () => make_evar_from_constr base_name; Control.shelve()).
+  Control.focus 2 (Int.add m 1) (fun () => refine_goal_with_evar base_name; Control.shelve()).

--- a/theories/Util/Evars.v
+++ b/theories/Util/Evars.v
@@ -1,0 +1,31 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+Require Export Ltac2.Ltac2.
+
+Require Import Waterproof.Waterproof.
+
+Ltac2 @ external make_evar_from_constr : string -> unit := "coq-waterproof" "make_evar_from_constr_external".
+
+Ltac2 @ external get_evar_list_in_term : constr -> evar list := "coq-waterproof" "evar_list_from_term_external".
+
+Ltac2 rename_blank_evars_in_term (base_name : string) (x : constr) :=
+  let evars := get_evar_list_in_term x in
+  let m := List.length evars in
+  List.fold_left (fun _ ev => Control.new_goal ev) (evars) ();
+  Control.focus 2 (Int.add m 1) (fun () => make_evar_from_constr base_name; Control.shelve()).


### PR DESCRIPTION
Allow for choosing blanks in specialize statements. For example:

```
Goal (forall a b c : nat, a + b + c = 0) -> False.
Proof.
intro H.
Use a := _, b := _, c := _ in (H).
It holds that (?a + ?b + ?c = 0).
```

When a user provides a blank for postponing the choice of a variable, the tactic automatically creates a variable (an evar) with a name based on the binder name that was selected.

The PR includes renaming of evars also for the choose tactic.