### PR TITLE
Feat binders

### DIFF
--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -96,3 +96,8 @@ Proof.
   (* In this case, the blank evar should be renamed to `x` *)
   assert (?x = 0). (* This checks if ?x exists and can be referred to. *)
 Abort.
+
+(** Test 11: Warn on different variable name *)
+Goal exists n : nat, n + 1 = n + 1.
+    Choose m := 1.
+Abort.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -97,7 +97,27 @@ Proof.
   assert (?x = 0). (* This checks if ?x exists and can be referred to. *)
 Abort.
 
+(** ** Tests about choosing different variable names *)
+
 (** Test 11: Warn on different variable name *)
 Goal exists n : nat, n + 1 = n + 1.
+Proof.
     Choose m := 1.
+Abort.
+
+(** Test 12: Warn on different variable name when binder is shielded,
+    because of an already existing definition. *)
+Goal exists n : nat, n + 1 = n + 1.
+Proof.
+    set (n := 3).
+    Choose n0 := 2.
+Abort.
+
+(** Test 12: Warn on different variable name when binder is shielded,
+    because of an already existing definition, using that already
+    defined variable *)
+Goal exists n : nat, n + 1 = n + 1.
+Proof.
+    set (n := 3).
+    Choose n0 := n.
 Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -150,3 +150,11 @@ It holds that (forall b : nat, ?a + b = 0) (i).
 Use b := ?a in (i).
 It holds that (?a + ?a = 0).
 Abort.
+
+(** Test 13 : TODO: illustration of slightly strange behavior *)
+
+Goal (forall n : nat, f n = n) -> True.
+intro H.
+set (n := 2). (* This renames the binder *)
+Fail Use n0 := 5 in (H).
+Abort.

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -133,8 +133,79 @@ Proof.
   Take n : nat and x, y : R.
 Abort.
 
-(** Test 14: Warn on using different variable name *)
+(** ** Tests about variable names *)
+
+(** Test 14: Warn on using a different variable name *)
+Goal forall n : nat, n = n.
+  Take m : nat. (* This should produce a warning *)
+Abort.
+
+(** Test 15: Warn on using different variable name, if variable has
+    visually been renamed. *)
 Goal forall n : nat, n = n.
 Proof.
-  Take m : nat.
+  set (n := 1).
+  Take m : nat. (* This should produce a warning *)
+Abort.
+
+(** Test 16: Do not warn if variable has visually been renamed (although 
+    internally, the binder name stays the same) *)
+Goal forall n : nat, n = n.
+Proof.
+  set (n := 1).
+  Take n0 : nat. (* This should produce no warning. *)
+Abort.
+
+(** Test 17: Warn on using different variable name *)
+Goal forall m n : nat, n = m.
+Proof.
+  Take n : nat. (* This should produce a warning *)
+  Take n0 : nat. (* This should produce no warning *)
+Abort.
+
+(** Test 18: Warn on using different variable name *)
+Goal forall m n : nat, n = m.
+Proof.
+  set (m := 3).
+  set (n := 4).
+  Take m0 : nat. (* This should produce no warning *)
+  Take n0 : nat. (* This should produce no warning *)
+Abort.
+
+(** Test 19: If a statement reuses a same binder name, and 
+    variable are introduced one by one, go with the
+    visually rename binder. *)
+Goal forall n : nat, forall n : nat, n = n.
+Proof.
+  Take n : nat.
+  Take n0 : nat. (* This should produce no warning *)
+Abort.
+
+(** Test 20: Fail when twice the same variable is introduced *)
+Goal forall n : nat, forall n : nat, n = n.
+Proof.
+  Fail Take n, n : nat. (* This should also produce a warning *)
+Abort.
+
+(** Test 21: It should be possible to provide fresh variable names
+    (although in the expected order) *)
+Goal forall n : nat, forall n : nat, n = n.
+Proof.
+  Take n, n0 : nat. (* This should produce no warning *)
+Abort.
+
+(** Test 22: It should be possible to provide fresh variable names
+    (although in the expected order) case with 3 variables *)
+Goal forall n : nat, forall n : nat, forall n : nat, n = n.
+Proof.
+  Take n, n0, n1 : nat. (* This should produce no warning *)
+Abort.
+
+(** Test 23: It should  be possible to provide fresh variable names
+    (although in the expected order), if also already a
+    variable has been defined with the same name. *)
+Goal forall n : nat, forall n : nat, forall n : nat, n = n.
+Proof.
+  (set (n := 1)).
+  Take n0, n1, n2 : nat. (* This should produce no warning *)
 Abort.

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -132,4 +132,9 @@ Proof.
   Fail Take n : nat and x, y : R and f : (R -> R).
   Take n : nat and x, y : R.
 Abort.
-    
+
+(** Test 14: Warn on using different variable name *)
+Goal forall n : nat, n = n.
+Proof.
+  Take m : nat.
+Abort.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -60,9 +60,15 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
           match Constr.Binder.name b with
           | None => () (* TODO: is it true that we want to do nothing here?,
                           i.e. in the case of anonymous binders. *)
-          | Some b_name =>
-            if Bool.neg (Ident.equal b_name s) then
-              warn (concat_list [of_string "A variable name "; of_ident b_name;
+          | Some binder_name =>
+            (* If a variable already exists, the binder gets renamed visually, but 
+            the binder name internally remains the same.
+            This gives confusing behavior. To go around this,
+            we try to guess what the binder got renamed into by introducing a fresh
+            ident based on the binder name. *)
+            let fresh_binder_name := Fresh.fresh (Fresh.Free.of_goal () ) binder_name in 
+            if Bool.neg (Ident.equal fresh_binder_name s) then
+              warn (concat_list [of_string "A variable name "; of_ident fresh_binder_name;
                 of_string " was expected, but a variable name "; of_ident s;
                 of_string " was given.
 The variable has been renamed."])

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -28,6 +28,11 @@ Local Ltac2 concat_list (ls : message list) : message :=
 
 (* Ltac2 Type exn ::= [ ChooseError(string) ]. *)
 
+Local Ltac2 _binder_name_equal (name : ident) (b : binder) :=
+  match Constr.Binder.name b with
+  | None => false
+  | Some binder_name => Ident.equal name binder_name
+  end.
 
 (** * Choose *)
 
@@ -48,7 +53,23 @@ Local Ltac2 concat_list (ls : message list) : message :=
 *)
 Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
   lazy_match! goal with
-    | [ |- exists _ : _, _] =>
+    | [ |- ex ?a] =>
+      (* Check for correct binder name *)
+      match Constr.Unsafe.kind a with
+      | Constr.Unsafe.Lambda b _ =>
+          match Constr.Binder.name b with
+          | None => () (* TODO: is it true that we want to do nothing here?,
+                          i.e. in the case of anonymous binders. *)
+          | Some b_name =>
+            if Bool.neg (Ident.equal b_name s) then
+              warn (concat_list [of_string "A variable name "; of_ident b_name;
+                of_string " was expected, but a variable name "; of_ident s;
+                of_string " was given.
+The variable has been renamed."])
+            else ()
+          end
+      | _ => ()
+      end;
       set ($s := $t);
       let v := Control.hyp s in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in

--- a/theories/Tactics/Take.v
+++ b/theories/Tactics/Take.v
@@ -53,16 +53,24 @@ Local Ltac2 intro_ident (id : ident) (type : constr) :=
       let ct := get_coerced_type type in
       (* Check whether we need a variable of type [type], including coercions of [type]. *)
       match check_constr_equal (Constr.Binder.type b) ct with
-        | true  => intro $id
+        | true  => ()
         | false => throw (too_many_of_type_message type)
       end;
       match Constr.Binder.name b with
       | None => () (* TODO: check if we really want to do nothing here *)
-      | Some b_name =>
-          if Ident.equal id b_name then () else
-            warn (concat_list [of_string "Expected variable name "; of_ident b_name;
+      | Some binder_name =>
+          (* If a variable already exists, the binder gets renamed visually, but 
+            the binder name internally remains the same.
+            This gives confusing behavior. To go around this,
+            we try to guess what the binder got renamed into by introducing a fresh
+            ident based on the binder name. *)
+          let fresh_binder_name := Fresh.fresh (Fresh.Free.of_goal () ) binder_name in
+          if Ident.equal id fresh_binder_name then () else
+            warn (concat_list [of_string "Expected variable name "; of_ident fresh_binder_name;
               of_string " instead of "; of_ident id; of_string "."])
-      end
+      end;
+      (* Finally introduce the variable *)
+      intro $id
     | _ => throw (too_many_of_type_message type)
   end.
 


### PR DESCRIPTION
Check for binder names in Choose and Take tactics.

For instance
```
Goal exists n : nat, n + 1 = n + 1.
    Choose m := 1.
Abort.
```
generates a warning, as does
```
Goal forall n : nat, n = n.
Proof.
  Take m : nat.
Abort.
```