### PR TITLE
Create a devcontainer for the project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM coqorg/coq:8.17.1-ocaml-4.14.2-flambda
+
+RUN opam update; \
+    opam install coq-lsp.0.1.8+8.17 -y; \
+    opam install ocaml-lsp-server -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "coq-waterproof dev container for Coq 8.17",
+
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
+    "onCreateCommand": "echo \"Installing coq-waterproof for the first time\" && dune build -p coq-waterproof && autoreconf -i -s && sudo env PATH=$PATH ./configure && sed -i 's/# -R/-R/' _CoqProject && sed -i 's/# -I/-I/' _CoqProject",
+
+    "customizations": {
+        "vscode": {
+            "extensions" : [ "ejgallego.coq-lsp",
+                             "ocamllabs.ocaml-platform" ]
+        }
+    }
+}


### PR DESCRIPTION
Using the devcontainer should be useful for instance in using github codespaces for editing the project, but mostly this is a tryout for creating a devcontainer for waterproof exercise sheets.