### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/tests/chains/Manipulation.v
+++ b/tests/chains/Manipulation.v
@@ -18,8 +18,8 @@
 
 Require Import Ltac2.Ltac2.
 
-Require Import Coq.Reals.Reals.
-Require Import micromega.Lra.
+From Coq Require Import Reals.
+From Coq Require Import Lra.
 
 Require Import Waterproof.Automation.
 Require Import Waterproof.Notations.

--- a/tests/tactics/Conclusion.v
+++ b/tests/tactics/Conclusion.v
@@ -19,8 +19,8 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Coq.Reals.Reals.
-Require Import micromega.Lra.
+From Coq Require Import Reals.
+From Coq Require Import Lra.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -19,14 +19,14 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Rbase.
-Require Import Qreals.
-Require Import Rfunctions.
-Require Import SeqSeries.
-Require Import Rtrigo.
-Require Import Ranalysis.
-Require Import Integration.
-Require Import micromega.Lra.
+From Coq Require Import Rbase.
+From Coq Require Import Qreals.
+From Coq Require Import Rfunctions.
+From Coq Require Import SeqSeries.
+From Coq Require Import Rtrigo.
+From Coq Require Import Ranalysis.
+From Coq Require Import Integration.
+From Coq Require Import Lra.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/theories/Automation/Hints.v
+++ b/theories/Automation/Hints.v
@@ -18,15 +18,15 @@
 
 Require Import Ltac2.Ltac2.
 
-Require Import Arith.PeanoNat.
-Require Import Classical_Pred_Type.
-Require Import Lia.
-Require Import Lra.
-Require Import Logic.ClassicalEpsilon.
-Require Import Reals.Reals.
-Require Import Reals.Rdefinitions.
-Require Import Sets.Classical_sets.
-Require Import Sets.Ensembles.
+From Coq Require Import PeanoNat.
+From Coq Require Import Classical_Pred_Type.
+From Coq Require Import Lia.
+From Coq Require Import Lra.
+From Coq Require Import ClassicalEpsilon.
+From Coq Require Import Reals.
+From Coq Require Import Rdefinitions.
+From Coq Require Import Classical_sets.
+From Coq Require Import Ensembles.
 
 Require Import Chains.
 Require Import Libs.Negation.

--- a/theories/Libs/Analysis/MetricSpaces.v
+++ b/theories/Libs/Analysis/MetricSpaces.v
@@ -16,9 +16,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Reals.ROrderedType.
-Require Import micromega.Lra.
+From Coq Require Import Reals.
+From Coq Require Import ROrderedType.
+From Coq Require Import Lra.
 
 Require Import Tactics.
 Require Import Automation.

--- a/theories/Libs/Analysis/StrongInductionIndexSequence.v
+++ b/theories/Libs/Analysis/StrongInductionIndexSequence.v
@@ -16,11 +16,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Lia.
-Require Import Arith.
-Require Import Arith.Compare.
-Require Import ClassicalChoice.
-Require Import ChoiceFacts.
+From Coq Require Import Lia.
+From Coq Require Import Arith.
+From Coq Require Import Compare.
+From Coq Require Import ClassicalChoice.
+From Coq Require Import ChoiceFacts.
 
 Require Export Libs.Analysis.SubsequencesMetric.
 


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
