### PR TITLE
Feat test warnings and errors

### DIFF
--- a/_CoqProjectForMake
+++ b/_CoqProjectForMake
@@ -110,7 +110,7 @@ tests/chains/Manipulation.v
 
 ## Automation
 
-### General  
+### General
 tests/automation/Shield.v
 tests/automation/Chains.v
 
@@ -140,10 +140,13 @@ tests/tactics/Specialize.v
 tests/tactics/Take.v
 tests/tactics/ToShow.v
 tests/tactics/Unfold.v
+tests/tactics/Help.v
 
 ## Util
 tests/util/Evars.v
 tests/util/MessagesToUser.v
+tests/util/Assertions.v
+tests/util/TypeCorrector.v
 
 ## Libs
 tests/libs/Negation.v

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -78,6 +78,8 @@ let warn (input : Pp.t) : unit Proofview.tactic =
   if !redirect_warnings then Proofview.tclUNIT () else
     Proofview.tclUNIT @@ Feedback.msg_warning input
 
+let warn' (input : Pp.t) ?(proc = Feedback.msg_warning) : unit Proofview.tactic =
+  Proofview.tclUNIT @@ proc input
 (**
   Throws an error
 *)

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -120,7 +120,7 @@ let throw ?(info: Exninfo.info = Exninfo.null) (exn: wexn): 'a =
   let fatal = Exninfo.add info fatal_flag () in
   CErrors.user_err ?info:(Some fatal) (pr_wexn exn)
 
-(** 
+(**
   Send a message
 *)
 let message (lvl : Feedback.level) (input : Pp.t) : unit Proofview.tactic =
@@ -129,13 +129,13 @@ let message (lvl : Feedback.level) (input : Pp.t) : unit Proofview.tactic =
   else
     Proofview.tclUNIT @@ feedback (Message (lvl, None, input))
 
-(** 
+(**
   Send a warning
 *)
 let warn (input : Pp.t) : unit Proofview.tactic =
   message Warning input
 
-(** 
+(**
   Send a notice
 *)
 let notice (input : Pp.t) : unit Proofview.tactic =
@@ -147,8 +147,6 @@ let notice (input : Pp.t) : unit Proofview.tactic =
 let inform (input : Pp.t) : unit Proofview.tactic =
   message Info input
 
-let warn' (input : Pp.t) ?(proc = Feedback.msg_warning) : unit Proofview.tactic =
-  Proofview.tclUNIT @@ proc input
 (**
   Throw an error
 *)

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -17,8 +17,6 @@
 (******************************************************************************)
 
 open Pp
-open Proofview
-open Proofview.Notations
 open Feedback
 
 let wp_debug_log = Summary.ref ~name:"wp_debug_log" []

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -111,7 +111,7 @@ let throw ?(info: Exninfo.info = Exninfo.null) (exn: wexn): 'a =
   CErrors.user_err ?info:(Some fatal) (pr_wexn exn)
 
 (** 
-  Sends a warning and returns the message as a string
+  Sends a warning
 *)
 let warn (input : Pp.t) : unit Proofview.tactic =
   if !redirect_warnings then 
@@ -119,7 +119,17 @@ let warn (input : Pp.t) : unit Proofview.tactic =
   else
     Proofview.tclUNIT @@ msg_warning input
 
-exception RedirectedToUserException of Pp.t
+(** 
+  Sends a notice
+*)
+let notice (input : Pp.t) : unit Proofview.tactic =
+  Proofview.tclUNIT @@ msg_notice input
+
+(**
+  Send an info message
+*)
+let inform (input : Pp.t) : unit Proofview.tactic =
+  Proofview.tclUNIT @@ msg_info input
 
 let warn' (input : Pp.t) ?(proc = Feedback.msg_warning) : unit Proofview.tactic =
   Proofview.tclUNIT @@ proc input
@@ -129,9 +139,7 @@ let warn' (input : Pp.t) ?(proc = Feedback.msg_warning) : unit Proofview.tactic 
 let err (input : Pp.t) : unit Proofview.tactic =
   (* Route the message to our own logger. Note that we need to follow
      the feedback mechanism otherwise the message does not arrive in the log *)
-  if !redirect_errors then
-    tclZERO (RedirectedToUserException input)
-  else throw (ToUserError input)
+  throw (ToUserError input)
 
 (**
   Return the last warning

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -43,13 +43,17 @@ let feedback_log (lvl : level) : Pp.t list ref =
 *)
 let wp_feedback_logger_id = Summary.ref ~name: "wp_feedback_logger_id" None
 
+let info_counter = Summary.ref ~name:"info_counter" 0
+
 (**
   A custom feedback logger for waterproof
 *)
 let wp_feedback_logger (fb : feedback) : unit =
   match fb.contents with
   | Message (lvl, _, msg) ->
-    feedback_log lvl := msg :: !(feedback_log lvl)
+    (feedback_log lvl :=
+      (msg) :: !(feedback_log lvl);
+    info_counter := !info_counter + 1)
   | _ -> ()
 
 (**

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -17,6 +17,26 @@
 (******************************************************************************)
 
 (**
+  A rudimentary feedback log
+*)
+val feedback_log : Pp.t list ref
+
+(**
+  The id that we obtained when registering wp_feedback_logger as a feeder in Feedback.mli
+*)
+val wp_feedback_logger_id : int option ref
+
+(**
+  Our own logger that we add as a feeder to Coq's feedback mechanism in Feedback.mli
+*)
+val wp_feedback_logger : Feedback.feedback -> unit
+
+(**
+  Adds the wp_feedback_logger to Coq's feeedback mechanism
+*)
+val add_wp_feedback_logger : unit -> unit
+
+(**
   Should hypothesis hints be printed (For instance on how you can use a forall statement)?
 *)
 val print_hypothesis_help : bool ref
@@ -27,9 +47,16 @@ val print_hypothesis_help : bool ref
 val last_thrown_warning : Pp.t option ref
 
 (**
-  Redirect warnings: this is useful when testing the plugin
+  Redirect warnings: this is useful when testing the plugin: meant to redirect Waterproof
+  errors directly to the log
 *)
 val redirect_warnings : bool ref
+
+(**
+  Redirect errors: this is useful when testing the plugin: meant to redirect errors
+  to Control.zero rather than CErrors.user_err
+*)
+val redirect_errors : bool ref
 
 (**
   Type of exceptions used in Wateproof
@@ -63,9 +90,3 @@ val err :
   Check the last warning against a string
 *)
 val get_last_warning : unit -> Pp.t option Proofview.tactic
-
-(**
-  Catch an error and return the message
-*)
-val catch_error_return_message : 'a Proofview.tactic ->
-    Pp.t option Proofview.tactic

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -22,6 +22,16 @@
 val print_hypothesis_help : bool ref
 
 (**
+  The last thrown warning
+*)
+val last_thrown_warning : Pp.t option ref
+
+(**
+  Redirect warnings: this is useful when testing the plugin
+*)
+val redirect_warnings : bool ref
+
+(**
   Type of exceptions used in Wateproof
 *)
 type wexn =
@@ -48,3 +58,14 @@ val warn :
 *)
 val err :
   Pp.t -> unit Proofview.tactic
+
+(**
+  Check the last warning against a string
+*)
+val get_last_warning : unit -> Pp.t option Proofview.tactic
+
+(**
+  Catch an error and return the message
+*)
+val catch_error_return_message : 'a Proofview.tactic ->
+    Pp.t option Proofview.tactic

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -19,7 +19,7 @@
 (**
   A rudimentary feedback log
 *)
-val feedback_log : Pp.t list ref
+val feedback_log : Feedback.level -> Pp.t list ref
 
 (**
   The id that we obtained when registering wp_feedback_logger as a feeder in Feedback.mli
@@ -50,7 +50,7 @@ val last_thrown_warning : Pp.t option ref
   Redirect warnings: this is useful when testing the plugin: meant to redirect Waterproof
   errors directly to the log
 *)
-val redirect_warnings : bool ref
+val redirect_feedback : bool ref
 
 (**
   Redirect errors: this is useful when testing the plugin: meant to redirect errors
@@ -97,6 +97,12 @@ val inform :
 *)
 val err :
   Pp.t -> unit Proofview.tactic
+
+(**
+  A general function for sending feedback
+*)
+val message :
+  Feedback.level -> Pp.t -> unit Proofview.tactic
 
 (**
   Check the last warning against a string

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -81,6 +81,18 @@ val warn :
   Pp.t -> unit Proofview.tactic
 
 (**
+  Sends a notice
+*)
+val notice :
+  Pp.t -> unit Proofview.tactic
+
+(**
+  Send an info message
+*)
+val inform :
+  Pp.t -> unit Proofview.tactic
+
+(**
   Throws an error
 *)
 val err :

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -87,3 +87,17 @@ VERNAC COMMAND EXTEND PrintVersionSideEff CLASSIFIED AS SIDEFF
       Feedback.msg_notice (Pp.str waterproof_version)
     }
 END
+
+VERNAC COMMAND EXTEND RedirectWarningsEnableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Enable" "Redirect" "Warnings" ] ->
+    {
+      redirect_warnings := true
+    }
+END
+
+VERNAC COMMAND EXTEND RedirectWarningsDisableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Disable" "Redirect" "Warnings" ] ->
+    {
+      redirect_warnings := false
+    }
+END

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -101,3 +101,25 @@ VERNAC COMMAND EXTEND RedirectWarningsDisableSideEff CLASSIFIED AS SIDEFF
       redirect_warnings := false
     }
 END
+
+
+VERNAC COMMAND EXTEND RedirectErrorsEnableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Enable" "Redirect" "Errors" ] ->
+    {
+      redirect_errors := true
+    }
+END
+
+VERNAC COMMAND EXTEND RedirectErrorsDisableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Disable" "Redirect" "Errors" ] ->
+    {
+      redirect_errors := false
+    }
+END
+
+VERNAC COMMAND EXTEND AddWpLoggerSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Enable" "Logging" ] ->
+    {
+      add_wp_feedback_logger ()
+    }
+END

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -89,16 +89,16 @@ VERNAC COMMAND EXTEND PrintVersionSideEff CLASSIFIED AS SIDEFF
 END
 
 VERNAC COMMAND EXTEND RedirectWarningsEnableSideEff CLASSIFIED AS SIDEFF
-  | [ "Waterproof" "Enable" "Redirect" "Warnings" ] ->
+  | [ "Waterproof" "Enable" "Redirect" "Feedback" ] ->
     {
-      redirect_warnings := true
+      redirect_feedback := true
     }
 END
 
 VERNAC COMMAND EXTEND RedirectWarningsDisableSideEff CLASSIFIED AS SIDEFF
-  | [ "Waterproof" "Disable" "Redirect" "Warnings" ] ->
+  | [ "Waterproof" "Disable" "Redirect" "Feedback" ] ->
     {
-      redirect_warnings := false
+      redirect_feedback := false
     }
 END
 

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -197,3 +197,15 @@ let () =
 let () =
   define1 "get_print_hypothesis_flag_external" unit @@
     fun input -> tclUNIT @@ of_bool !print_hypothesis_help
+
+let () =
+  define1 "get_last_warning_external" unit @@
+    fun input -> get_last_warning input >>=
+      fun pp_option -> tclUNIT @@ of_option of_pp pp_option
+
+let my_thaw f = Tac2ffi.apply f [of_unit ()]
+
+let () =
+  define1 "catch_error_return_message_external" closure @@
+    fun tac -> catch_error_return_message (my_thaw tac) >>=
+      fun pp_option -> tclUNIT @@ of_option of_pp pp_option

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -180,9 +180,19 @@ let () =
       warn input >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
+  define1 "notice_external" pp @@
+    fun input ->
+      notice input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
   define1 "throw_external" pp @@
     fun input ->
       err input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
+  define1 "inform_external" pp @@
+    fun input ->
+      inform input >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
   define1 "refine_goal_with_evar_external" string @@

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -199,13 +199,14 @@ let () =
     fun input -> tclUNIT @@ of_bool !print_hypothesis_help
 
 let () =
+  define1 "get_redirect_errors_flag_external" unit @@
+    fun input -> tclUNIT @@ of_bool !redirect_errors
+
+let () =
   define1 "get_last_warning_external" unit @@
     fun input -> get_last_warning input >>=
       fun pp_option -> tclUNIT @@ of_option of_pp pp_option
 
-let my_thaw f = Tac2ffi.apply f [of_unit ()]
-
 let () =
-  define1 "catch_error_return_message_external" closure @@
-    fun tac -> catch_error_return_message (my_thaw tac) >>=
-      fun pp_option -> tclUNIT @@ of_option of_pp pp_option
+  define1 "get_feedback_log_external" unit @@
+    fun input -> tclUNIT @@ of_list of_pp !feedback_log

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -148,6 +148,38 @@ let () =
   define0 "database_type_decidability" @@ tclUNIT @@ database_type_to_valexp Decidability;
   define0 "database_type_shorten" @@ tclUNIT @@ database_type_to_valexp Shorten
 
+(** Converts a {! Feedback.level} into a [valexpr] *)
+let feedback_lvl_to_valexpr (feedback_lvl: Feedback.level): valexpr = match feedback_lvl with
+  | Debug -> ValInt (-1)
+  | Info -> ValInt 0
+  | Notice -> ValInt 1
+  | Warning -> ValInt 2
+  | Error -> ValInt 3
+
+(** Converts a [valexpr] into a {! Feedback.level} *)
+let feedback_lvl_from_valexpr (value : valexpr): Feedback.level = match value with
+  | ValInt n ->
+    let feedback_lvl = match n with
+      | -1 -> Feedback.Debug
+      | 0 -> Info
+      | 1 -> Notice
+      | 2 -> Warning
+      | 3 -> Error
+      | _ -> throw (CastError "cannot cast an [int] outside {-1, 0, 1, 2, 3} into a [Feedback.level]")
+    in feedback_lvl
+  | _ -> throw (CastError "cannot cast something different from an [int] into a [Feedback.level]")
+
+(** Pack the conversion functions for feedback levels into a representation *)
+let feedback_lvl_repr = make_repr feedback_lvl_to_valexpr feedback_lvl_from_valexpr
+
+(** Exports {! Feedback.level} to Ltac2 *)
+let () =
+  define0 "feedback_lvl_debug" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Debug;
+  define0 "feedback_lvl_info" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Info;
+  define0 "feedback_lvl_notice" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Notice;
+  define0 "feedback_lvl_warning" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Warning;
+  define0 "feedback_lvl_error" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Error
+
 (* Exports {! Waterprove.waterprove} to Ltac2 *)
 let () =
   define4 "waterprove" int bool (list (thunk constr)) (make_repr database_type_to_valexp database_type_from_valexp) @@
@@ -195,6 +227,11 @@ let () =
       inform input >>= fun () -> tclUNIT @@ of_unit ()
 
 let () =
+  define2 "message_external" feedback_lvl_repr pp @@
+    fun lvl input ->
+      message lvl input >>= fun () -> tclUNIT @@ of_unit ()
+
+let () =
   define1 "refine_goal_with_evar_external" string @@
     fun input -> refine_goal_with_evar input >>= fun () -> tclUNIT @@ of_unit ()
 
@@ -218,5 +255,5 @@ let () =
       fun pp_option -> tclUNIT @@ of_option of_pp pp_option
 
 let () =
-  define1 "get_feedback_log_external" unit @@
-    fun input -> tclUNIT @@ of_list of_pp !feedback_log
+  define1 "get_feedback_log_external" feedback_lvl_repr @@
+    fun input -> tclUNIT @@ of_list of_pp !(feedback_log input)

--- a/tests/libs/Analysis/StrongInductionIndexSequence.v
+++ b/tests/libs/Analysis/StrongInductionIndexSequence.v
@@ -42,7 +42,7 @@ Require Import Waterproof.Tactics.
 Goal (exists n : nat -> nat, is_index_seq n /\ forall k : nat, Q (n k)).
 Proof.
   Define the index sequence n inductively.
-  - Choose n0 := 0.
+  - Choose n_0 := 0.
     admit.
   - Take k : ℕ and assume n(0),...,n(k) are defined.
     Assume that (forall l : nat, l <= k -> Q (n l)).

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -22,6 +22,7 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
 (** Test 0: This should choose m equal to n *)
@@ -60,11 +61,11 @@ Goal forall n : nat, ( ( (n = n) \/ (n + 1 = n + 1) ) -> (n + 1 = n + 1)).
     Fail Choose m := n.
 Abort.
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 
 (** Test 5: Choose a blank *)
 Goal exists n : nat, n + 1 = n + 1.
-    assert_warns_with_string (fun () => Choose n := (_))
+    assert_feedback_with_string (fun () => Choose n := (_)) Warning
 "Please come back to this line to make a definitive choice for n.
 For now you can use that 
 (n = ?n)".
@@ -72,7 +73,7 @@ Abort.
 
 (** Test 6: Choose a named evar *)
 Goal exists n : nat, n + 1 = n + 1.
-    assert_warns_with_string (fun () => Choose n := (?[m]))
+    assert_feedback_with_string (fun () => Choose n := (?[m])) Warning
 "Please come back to this line to make a definitive choice for n.
 For now you can use that 
 (n = ?m)".
@@ -80,7 +81,7 @@ Abort.
 
 (** Test 7: Choose a blank check that blank was renamed *)
 Goal exists n : nat, n + 1 = n + 1.
-    assert_warns_with_string (fun () => Choose n := (_))
+    assert_feedback_with_string (fun () => Choose n := (_)) Warning
 "Please come back to this line to make a definitive choice for n.
 For now you can use that 
 (n = ?n)".

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -60,19 +60,30 @@ Goal forall n : nat, ( ( (n = n) \/ (n + 1 = n + 1) ) -> (n + 1 = n + 1)).
     Fail Choose m := n.
 Abort.
 
+Waterproof Enable Redirect Warnings.
+
 (** Test 5: Choose a blank *)
 Goal exists n : nat, n + 1 = n + 1.
-    Choose n := (_).
+    assert_warns_with_string (fun () => Choose n := (_))
+"Please come back to this line to make a definitive choice for n.
+For now you can use that 
+(n = ?n)".
 Abort.
 
 (** Test 6: Choose a named evar *)
 Goal exists n : nat, n + 1 = n + 1.
-    Choose n := (?[m]).
+    assert_warns_with_string (fun () => Choose n := (?[m]))
+"Please come back to this line to make a definitive choice for n.
+For now you can use that 
+(n = ?m)".
 Abort.
 
-(** Test 7: Choose a blank check tha blank was renamed *)
+(** Test 7: Choose a blank check that blank was renamed *)
 Goal exists n : nat, n + 1 = n + 1.
-    Choose n := (_).
+    assert_warns_with_string (fun () => Choose n := (_))
+"Please come back to this line to make a definitive choice for n.
+For now you can use that 
+(n = ?n)".
     assert (?n = 0).
 Abort.
 

--- a/tests/tactics/Conclusion.v
+++ b/tests/tactics/Conclusion.v
@@ -26,6 +26,7 @@ Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Notations.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
 Waterproof Enable Automation RealsAndIntegers.
@@ -55,7 +56,7 @@ Lemma test_we_conclude_2: True.
 Proof.
     Fail We conclude that False.
 Abort.
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 Waterproof Enable Redirect Errors.
 (** * Test 3
     Warning case: provided goal is equivalent, 
@@ -63,7 +64,7 @@ Waterproof Enable Redirect Errors.
 *)
 Lemma test_we_conclude_3: 2 = 2.
 Proof.
-    assert_warns_with_string (fun () => We conclude that (1+1 = 2))
+    assert_feedback_with_string (fun () => We conclude that (1+1 = 2)) Warning
 "The statement you provided does not exactly correspond to what you need to show. 
 This can make your proof less readable.".
 Qed.
@@ -123,7 +124,7 @@ Qed.
 *)
 Lemma test_by_we_conclude_3: 2 = 1 + 1.
 Proof.
-    assert_warns_with_string (fun () => We conclude that (2 = 2))
+    assert_feedback_with_string (fun () => We conclude that (2 = 2)) Warning
 "The statement you provided does not exactly correspond to what you need to show. 
 This can make your proof less readable.".
 Qed.

--- a/tests/tactics/Conclusion.v
+++ b/tests/tactics/Conclusion.v
@@ -55,15 +55,17 @@ Lemma test_we_conclude_2: True.
 Proof.
     Fail We conclude that False.
 Abort.
-
+Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Errors.
 (** * Test 3
     Warning case: provided goal is equivalent, 
         but uses an alternative notation.
 *)
 Lemma test_we_conclude_3: 2 = 2.
 Proof.
-    print (of_string "Should raise warning:").
-    We conclude that (1+1 = 2).
+    assert_warns_with_string (fun () => We conclude that (1+1 = 2))
+"The statement you provided does not exactly correspond to what you need to show. 
+This can make your proof less readable.".
 Qed.
 
 (** * Test 4
@@ -121,8 +123,9 @@ Qed.
 *)
 Lemma test_by_we_conclude_3: 2 = 1 + 1.
 Proof.
-    print (of_string "Should raise warning:").
-    We conclude that (2 = 2).
+    assert_warns_with_string (fun () => We conclude that (2 = 2))
+"The statement you provided does not exactly correspond to what you need to show. 
+This can make your proof less readable.".
 Qed.
 
 (** * Test 5
@@ -135,7 +138,9 @@ Lemma test_by_we_conclude_5: 1 < 2.
 Proof.
     assert (useless: 1 = 1).
     reflexivity.
-    Fail By test_by_we_conclude_1 we conclude that (1 < 2).
+    assert_fails_with_string 
+    (fun () => By test_by_we_conclude_1 we conclude that (1 < 2))
+"Could not verify this follows from test_by_we_conclude_1.".
 Abort.
 
 (** Additional tests 'By ...' clause.  *)

--- a/tests/tactics/Help.v
+++ b/tests/tactics/Help.v
@@ -22,50 +22,85 @@ Require Import Ltac2.Option.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Tactics.Help.
 Require Import Waterproof.Util.MessagesToUser.
+Require Import Waterproof.Util.Assertions.
 
 Waterproof Enable Hypothesis Help.
-Waterproof Enable Logging.
+Waterproof Enable Redirect Feedback.
 
 (** Test 0 : Suggest to follow advice in goal if goal is wrapped 
   or [False] (i.e. prove contradiction). *)
 Goal False.
-  Help.
+  assert_feedback_with_string (fun () => Help) Info
+"Follow the advice in the goal window.".
 Abort.
 
 (** Test 1 : Only suggest to follow advice in goal if goal is wrapped 
   or [False] (i.e. prove contradiction). *)
 Goal (forall n : nat, n = n) -> False.
   intros.
-  Help.
+  assert_feedback_with_string (fun () => Help) Info
+"Follow the advice in the goal window.".
 Abort.
 
 (** Test 2 : Suggest to solve directly if goal can be shown automatically. *)
 Goal True.
-  Help.
+  assert_feedback_with_string (fun () => Help) Info
+"The goal can be shown immediately, use
+    We conclude that (...).".
 Abort.
 
 (** Test 3 : Only suggest to solve directly if goal can be shown automatically. *)
 Goal (forall n : nat, n = n) -> True.
   intros.
-  Help.
+  assert_feedback_with_string (fun () => Help) Info
+"The goal can be shown immediately, use
+    We conclude that (...).".
 Abort.
 
 (** Test 4 : Report \forall hypotheses if available. *)
 Goal (forall n : nat, n = n) -> (forall m : nat, m + 1 = m + 1) -> (0 = 1).
   intros.
-  Help.
+  assert_feedback_with_strings (fun () => Help) Info
+["No direct hint available.
+Does the goal contain a definition that can be expanded?";
+"";
+"To use one of the ‘for all’-statements (∀)";
+"    (forall n : nat, n = n)";
+"    (forall m : nat, m + 1 = m + 1)";
+"use";
+"    Use ... := (...) in (...)."].
 Abort.
 
 (** Test 5 : Report \exists hypotheses if available. *)
 Goal (exists n : nat, n = n) -> (exists m : nat, m + 1 = m + 1) -> (0 = 1).
   intros.
-  Help.
+  assert_feedback_with_strings (fun () => Help) Info
+["No direct hint available.
+Does the goal contain a definition that can be expanded?";
+"";
+"To use one of the ‘there exists’-statements (∃)";
+"    (exists n : nat, n = n)";
+"    (exists m : nat, m + 1 = m + 1)";
+"use";
+"    Obtain ... according to (...)."].
 Abort.
 
 (** Test 6 : Report \forall and \exists hypotheses if available. *)
 Goal (forall n : nat, n = n) -> (exists m : nat, m = 0) -> (0 = 1).
   intros.
-  Help.
+  assert_feedback_with_strings (fun () => Help) Info
+["No direct hint available.
+Does the goal contain a definition that can be expanded?";
+"";
+"To use one of the ‘for all’-statements (∀)";
+"    (forall n : nat, n = n)";
+"use";
+"    Use ... := (...) in (...).";
+"";
+"To use one of the ‘there exists’-statements (∃)";
+"    (exists m : nat, m = 0)";
+"use";
+"    Obtain ... according to (...)."].
 Abort.
 
 
@@ -77,25 +112,37 @@ Require Import Waterproof.Tactics.ItHolds.
 (** Test 7: It holds that, no label. *)
 Goal False.
 Proof.
-  It holds that (forall n : nat, n = n).
+  assert_feedback_with_strings
+  (fun () => It holds that (forall n : nat, n = n)) Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (...)."].
 Abort.
 
 (** Test 8: It holds that, label. *)
 Goal False.
 Proof.
-  It holds that (forall n : nat, n = n) (i).
+  assert_feedback_with_strings
+  (fun () => It holds that (forall n : nat, n = n) (i)) Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (i)."].
 Abort.
 
 (** Test 9: By ... it holds that, no label. *)
 Goal False.
 Proof.
+  (** TODO: is this consistent with the statement 
+      without the by clause and with the since clause? *)
   By I it holds that (forall n : nat, True).
 Abort.
 
 (** Test 10: Since ... it holds that, no label. *)
 Goal False.
 Proof.
-  Since (True) it holds that (forall n : nat, n = n).
+  assert_feedback_with_strings
+  (fun () => Since (True) it holds that (forall n : nat, n = n))
+  Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (...)."].
 Abort.
 
 
@@ -104,19 +151,31 @@ Require Import Waterproof.Tactics.Assume.
 (** Test 11: Assume that, no label. *)
 Goal (forall n : nat, n = n) -> False.
 Proof.
-  Assume that (forall n : nat, n = n).
+  assert_feedback_with_strings
+  (fun () => Assume that (forall n : nat, n = n))
+  Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (...)."].
 Abort.
 
 (** Test 12: Assume that, label. *)
 Goal (forall n : nat, n = n) -> False.
 Proof.
-  Assume that (forall n : nat, n = n) (i).
+  assert_feedback_with_strings
+  (fun () => Assume that (forall n : nat, n = n) (i))
+  Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (i)."].
 Abort.
 
 (** Test 13: Assume negation. *)
 Goal not (forall n : nat, n = n).
 Proof.
-  Assume that (forall n : nat, n = n).
+  assert_feedback_with_strings
+  (fun () => Assume that (forall n : nat, n = n))
+  Info
+["To use (forall n : nat, n = n), use";
+"    Use ... := (...) in (...)."].
 Abort.
 
 
@@ -125,13 +184,21 @@ Require Import Waterproof.Tactics.Claims.
 (** Test 14: We claim that, no label. *)
 Goal False.
 Proof.
-  We claim that (forall n : nat, n = n).
+  assert_feedback_with_strings
+  (fun () => We claim that (forall n : nat, n = n))
+  Info
+["After proving (forall n : nat, n = n), use it with";
+"    Use ... := (...) in (...)."].
 Abort.
 
 (** Test 15: Assume that, label. *)
 Goal (forall n : nat, n = n) -> False.
 Proof.
-  We claim that (forall n : nat, n = n) (i).
+  assert_feedback_with_strings
+  (fun () => We claim that (forall n : nat, n = n) (i))
+  Info
+["After proving (forall n : nat, n = n), use it with";
+"    Use ... := (...) in (i)."].
 Abort.
 
 Waterproof Disable Hypothesis Help.
@@ -139,7 +206,7 @@ Waterproof Disable Hypothesis Help.
 (** Test 16: Test if no advice is indeed given if help is disabled. *)
 Goal False.
 Proof.
-  It holds that (forall n : nat, n = n).
+  assert_no_feedback
+  (fun () => It holds that (forall n : nat, n = n))
+  Info.
 Abort.
-
-Ltac2 Eval (get_feedback_log Info).

--- a/tests/tactics/Help.v
+++ b/tests/tactics/Help.v
@@ -21,8 +21,10 @@ Require Import Ltac2.Option.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Tactics.Help.
+Require Import Waterproof.Util.MessagesToUser.
 
 Waterproof Enable Hypothesis Help.
+Waterproof Enable Logging.
 
 (** Test 0 : Suggest to follow advice in goal if goal is wrapped 
   or [False] (i.e. prove contradiction). *)
@@ -139,3 +141,5 @@ Goal False.
 Proof.
   It holds that (forall n : nat, n = n).
 Abort.
+
+Ltac2 Eval (get_feedback_log Info).

--- a/tests/tactics/Postpone.v
+++ b/tests/tactics/Postpone.v
@@ -23,9 +23,10 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 
 (** By magic it holds that ....  *)
 
@@ -38,9 +39,9 @@ Abort.
 (** Test 1: postpone proof of claim. Claim added to hypotheses, warning raised. *)
 Goal (0 = 0).
 Proof.
-  assert_warns_with_string (fun () => By magic it holds that (False) (H2))
+  assert_feedback_with_string (fun () => By magic it holds that (False) (H2)) Warning
 "Please come back later to provide an actual proof of False.".
-  assert_warns_with_string (fun () => By magic it holds that (0 = 1) (H3))
+  assert_feedback_with_string (fun () => By magic it holds that (0 = 1) (H3)) Warning
 "Please come back later to provide an actual proof of (0 = 1).".
 Abort.
 
@@ -55,6 +56,6 @@ Abort.
 (** Test 3: postpone proof of conclusion. Raises warning. *)
 Goal (0 = 1).
 Proof.
-  assert_warns_with_string (fun () => By magic we conclude that (0 = 1))
+  assert_feedback_with_string (fun () => By magic we conclude that (0 = 1)) Warning
 "Please come back later to provide an actual proof of (0 = 1).".
 Abort.

--- a/tests/tactics/Postpone.v
+++ b/tests/tactics/Postpone.v
@@ -23,6 +23,9 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.Assertions.
+
+Waterproof Enable Redirect Warnings.
 
 (** By magic it holds that ....  *)
 
@@ -35,10 +38,11 @@ Abort.
 (** Test 1: postpone proof of claim. Claim added to hypotheses, warning raised. *)
 Goal (0 = 0).
 Proof.
-  By magic it holds that (False) (H2).
-  By magic it holds that (0 = 1) (H3).
+  assert_warns_with_string (fun () => By magic it holds that (False) (H2))
+"Please come back later to provide an actual proof of False.".
+  assert_warns_with_string (fun () => By magic it holds that (0 = 1) (H3))
+"Please come back later to provide an actual proof of (0 = 1).".
 Abort.
-
 
 (** By magic we conclude that ...  *)
 
@@ -51,5 +55,6 @@ Abort.
 (** Test 3: postpone proof of conclusion. Raises warning. *)
 Goal (0 = 1).
 Proof.
-  By magic we conclude that (0 = 1).
+  assert_warns_with_string (fun () => By magic we conclude that (0 = 1))
+"Please come back later to provide an actual proof of (0 = 1).".
 Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -22,6 +22,7 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Tactics.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Util.Assertions.
+Require Import Waterproof.Util.MessagesToUser.
 
 (** Test 0: This should be the expected behavior. *)
 Goal (forall n : nat, n = n) -> True.
@@ -100,13 +101,13 @@ Abort.
 
 (* -------------------------------------------------------------------------- *)
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 
 (** Test 8 : use a placeholder as variable name *)
 Goal (forall a b c : nat, a + b + c = 0) -> False.
 Proof.
 intro H.
-assert_warns_with_string (fun () => Use b := _ in (H))
+assert_feedback_with_string (fun () => Use b := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for b.".
 It holds that (forall a c : nat, a + ?b + c = 0) (i).
 Abort.
@@ -115,7 +116,7 @@ Abort.
 Goal (forall a b c : nat, a + b + c = 0) -> False.
 Proof.
 intro H.
-assert_warns_with_string (fun () => Use a := _, b := _, c := _ in (H))
+assert_feedback_with_string (fun () => Use a := _, b := _, c := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for a, b, c.".
 It holds that (?a + ?b + ?c = 0).
 Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -100,11 +100,14 @@ Abort.
 
 (* -------------------------------------------------------------------------- *)
 
+Waterproof Enable Redirect Warnings.
+
 (** Test 8 : use a placeholder as variable name *)
 Goal (forall a b c : nat, a + b + c = 0) -> False.
 Proof.
 intro H.
-Use b := _ in (H).
+assert_warns_with_string (fun () => Use b := _ in (H))
+"Please come back to this line later to make a definite choice for b.".
 It holds that (forall a c : nat, a + ?b + c = 0) (i).
 Abort.
 
@@ -112,7 +115,8 @@ Abort.
 Goal (forall a b c : nat, a + b + c = 0) -> False.
 Proof.
 intro H.
-Use a := _, b := _, c := _ in (H).
+assert_warns_with_string (fun () => Use a := _, b := _, c := _ in (H))
+"Please come back to this line later to make a definite choice for a, b, c.".
 It holds that (?a + ?b + ?c = 0).
 Abort.
 

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -29,9 +29,12 @@ Goal forall n : nat, n <= 2*n.
     Take n : nat.
 Abort.
 
-(** Test 1: Also this should work fine *)
+Waterproof Enable Redirect Warnings.
+
+(** Test 1: Also this should work fine, but with a warning *)
 Goal forall n : nat, n <= 2*n.
-    Take x : nat.
+    assert_warns_with_string (fun () => Take x : nat)
+"Expected variable name n instead of x.".
 Abort.
 
 (** Test 2: This should raise an error, because the type does not match*)
@@ -78,7 +81,14 @@ Abort.
 (** Test 6: Two sets of multiple variables of the same type,
     but with different names *)
 Goal forall (n m k: nat) (b1 b2: bool), Nat.odd (n + m + k) = andb b1 b2.
-    Take a, b, c : nat and d, e: bool.
+    assert_warns_with_strings
+    (fun () => Take a, b, c : nat and d, e: bool)
+[
+"Expected variable name n instead of a.";
+"Expected variable name m instead of b.";
+"Expected variable name k instead of c.";
+"Expected variable name b1 instead of d.";
+"Expected variable name b2 instead of e."].
 Abort.
 
 (** Test 7: not allowed to introduce so many bools *)
@@ -100,7 +110,8 @@ Abort.
     *)
 Goal forall (a b c d e f g: nat) (b1 b2: bool), 
     Nat.odd (a + b + c + d + e + f + g) = andb b1 b2.
-    assert_raises_error (fun() => Take a, b, c, d, e, f, g : nat and a, h: bool).
+    assert_fails_with_string (fun() => Take a, b, c, d, e, f, g : nat and a, h: bool)
+"Internal (err:(a is already used.))".
 Abort.
 
 (** Test 10: Two sets of multiple variables of the same type.
@@ -137,7 +148,8 @@ Abort.
 
 (** Test 14: Warn on using a different variable name *)
 Goal forall n : nat, n = n.
-  Take m : nat. (* This should produce a warning *)
+  assert_warns_with_string (fun () => Take m : nat)
+"Expected variable name n instead of m.".
 Abort.
 
 (** Test 15: Warn on using different variable name, if variable has
@@ -145,7 +157,8 @@ Abort.
 Goal forall n : nat, n = n.
 Proof.
   set (n := 1).
-  Take m : nat. (* This should produce a warning *)
+  assert_warns_with_string (fun () => Take m : nat)
+"Expected variable name n0 instead of m.".
 Abort.
 
 (** Test 16: Do not warn if variable has visually been renamed (although 
@@ -159,8 +172,9 @@ Abort.
 (** Test 17: Warn on using different variable name *)
 Goal forall m n : nat, n = m.
 Proof.
-  Take n : nat. (* This should produce a warning *)
-  Take n0 : nat. (* This should produce no warning *)
+  assert_warns_with_string (fun () => Take n : nat)
+"Expected variable name m instead of n.".
+  assert_no_warning (fun () => Take n0 : nat).
 Abort.
 
 (** Test 18: Warn on using different variable name *)
@@ -168,8 +182,8 @@ Goal forall m n : nat, n = m.
 Proof.
   set (m := 3).
   set (n := 4).
-  Take m0 : nat. (* This should produce no warning *)
-  Take n0 : nat. (* This should produce no warning *)
+  assert_no_warning (fun () => Take m0 : nat).
+  assert_no_warning (fun () => Take n0 : nat).
 Abort.
 
 (** Test 19: If a statement reuses a same binder name, and 
@@ -178,27 +192,29 @@ Abort.
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
   Take n : nat.
-  Take n0 : nat. (* This should produce no warning *)
+  assert_no_warning (fun () => Take n0 : nat).
 Abort.
 
 (** Test 20: Fail when twice the same variable is introduced *)
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
-  Fail Take n, n : nat. (* This should also produce a warning *)
+  assert_warns_with_string (fun () => assert_fails_with_string (fun () => Take n, n : nat)
+"Internal (err:(n is already used.))") (*This should produce an error ... *)
+"Expected variable name n0 instead of n.". (* ... and also produce a warning *)
 Abort.
 
 (** Test 21: It should be possible to provide fresh variable names
     (although in the expected order) *)
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
-  Take n, n0 : nat. (* This should produce no warning *)
+  assert_no_warning (fun () => Take n, n0 : nat).
 Abort.
 
 (** Test 22: It should be possible to provide fresh variable names
     (although in the expected order) case with 3 variables *)
 Goal forall n : nat, forall n : nat, forall n : nat, n = n.
 Proof.
-  Take n, n0, n1 : nat. (* This should produce no warning *)
+  assert_no_warning (fun () => Take n, n0, n1 : nat).
 Abort.
 
 (** Test 23: It should  be possible to provide fresh variable names
@@ -207,5 +223,5 @@ Abort.
 Goal forall n : nat, forall n : nat, forall n : nat, n = n.
 Proof.
   (set (n := 1)).
-  Take n0, n1, n2 : nat. (* This should produce no warning *)
+  assert_no_warning (fun () => Take n0, n1, n2 : nat).
 Abort.

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -22,6 +22,7 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
 (** Test 0: This should work fine *)
@@ -29,11 +30,11 @@ Goal forall n : nat, n <= 2*n.
     Take n : nat.
 Abort.
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 
 (** Test 1: Also this should work fine, but with a warning *)
 Goal forall n : nat, n <= 2*n.
-    assert_warns_with_string (fun () => Take x : nat)
+    assert_feedback_with_string (fun () => Take x : nat) Warning
 "Expected variable name n instead of x.".
 Abort.
 
@@ -81,8 +82,8 @@ Abort.
 (** Test 6: Two sets of multiple variables of the same type,
     but with different names *)
 Goal forall (n m k: nat) (b1 b2: bool), Nat.odd (n + m + k) = andb b1 b2.
-    assert_warns_with_strings
-    (fun () => Take a, b, c : nat and d, e: bool)
+    assert_feedback_with_strings
+    (fun () => Take a, b, c : nat and d, e: bool) Warning
 [
 "Expected variable name n instead of a.";
 "Expected variable name m instead of b.";
@@ -148,7 +149,7 @@ Abort.
 
 (** Test 14: Warn on using a different variable name *)
 Goal forall n : nat, n = n.
-  assert_warns_with_string (fun () => Take m : nat)
+  assert_feedback_with_string (fun () => Take m : nat) Warning
 "Expected variable name n instead of m.".
 Abort.
 
@@ -157,7 +158,7 @@ Abort.
 Goal forall n : nat, n = n.
 Proof.
   set (n := 1).
-  assert_warns_with_string (fun () => Take m : nat)
+  assert_feedback_with_string (fun () => Take m : nat) Warning
 "Expected variable name n0 instead of m.".
 Abort.
 
@@ -172,9 +173,9 @@ Abort.
 (** Test 17: Warn on using different variable name *)
 Goal forall m n : nat, n = m.
 Proof.
-  assert_warns_with_string (fun () => Take n : nat)
+  assert_feedback_with_string (fun () => Take n : nat) Warning
 "Expected variable name m instead of n.".
-  assert_no_warning (fun () => Take n0 : nat).
+  assert_no_feedback (fun () => Take n0 : nat) Warning.
 Abort.
 
 (** Test 18: Warn on using different variable name *)
@@ -182,8 +183,8 @@ Goal forall m n : nat, n = m.
 Proof.
   set (m := 3).
   set (n := 4).
-  assert_no_warning (fun () => Take m0 : nat).
-  assert_no_warning (fun () => Take n0 : nat).
+  assert_no_feedback (fun () => Take m0 : nat) Warning.
+  assert_no_feedback (fun () => Take n0 : nat) Warning.
 Abort.
 
 (** Test 19: If a statement reuses a same binder name, and 
@@ -192,14 +193,15 @@ Abort.
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
   Take n : nat.
-  assert_no_warning (fun () => Take n0 : nat).
+  assert_no_feedback (fun () => Take n0 : nat) Warning.
 Abort.
 
 (** Test 20: Fail when twice the same variable is introduced *)
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
-  assert_warns_with_string (fun () => assert_fails_with_string (fun () => Take n, n : nat)
+  assert_feedback_with_string (fun () => assert_fails_with_string (fun () => Take n, n : nat)
 "Internal (err:(n is already used.))") (*This should produce an error ... *)
+Warning
 "Expected variable name n0 instead of n.". (* ... and also produce a warning *)
 Abort.
 
@@ -207,14 +209,14 @@ Abort.
     (although in the expected order) *)
 Goal forall n : nat, forall n : nat, n = n.
 Proof.
-  assert_no_warning (fun () => Take n, n0 : nat).
+  assert_no_feedback (fun () => Take n, n0 : nat) Warning.
 Abort.
 
 (** Test 22: It should be possible to provide fresh variable names
     (although in the expected order) case with 3 variables *)
 Goal forall n : nat, forall n : nat, forall n : nat, n = n.
 Proof.
-  assert_no_warning (fun () => Take n, n0, n1 : nat).
+  assert_no_feedback (fun () => Take n, n0, n1 : nat) Warning.
 Abort.
 
 (** Test 23: It should  be possible to provide fresh variable names
@@ -223,5 +225,5 @@ Abort.
 Goal forall n : nat, forall n : nat, forall n : nat, n = n.
 Proof.
   (set (n := 1)).
-  assert_no_warning (fun () => Take n0, n1, n2 : nat).
+  assert_no_feedback (fun () => Take n0, n1, n2 : nat) Warning.
 Abort.

--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -22,7 +22,11 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
+
+Waterproof Enable Redirect Feedback.
+Waterproof Enable Redirect Errors.
 
 Definition foo : nat := 0.
 
@@ -32,7 +36,16 @@ Definition foo : nat := 0.
   to remove the line after use. *)
 Goal foo = 1.
 Proof.
-  Fail Expand the definition of foo.
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo)
+"Remove this line in the final version of your proof.")
+  Info
+["Expanded definition in statements where applicable.";
+"To include these statements, use (one of):";
+"";
+"  We need to show that (0 = 1)."].
 Abort.
 
 (* Test 2: unfold term in hypothese and goal, and throws an error suggesting 
@@ -40,14 +53,33 @@ Abort.
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo.
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo)
+"Remove this line in the final version of your proof.")
+  Info
+["Expanded definition in statements where applicable.";
+"To include these statements, use (one of):";
+"";
+"  We need to show that (0 = 1).";
+"";
+"  It holds that (0 = 0).";
+"  It holds that (0 = 2)."].
 Abort.
 
 (* Test 3: Unfold the term in a given statement, throw error suggesting
     to remove the line after use. *)
 Goal False.
 Proof.
-  Fail Expand the definition of foo in (foo = 4).
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo in (foo = 4))
+"Remove this line in the final version of your proof.")
+  Info
+["result:
+  (0 = 4)"].
 Abort.
 
 (* Test 4: Unfold term in given statement that matches goal,
@@ -55,7 +87,14 @@ Abort.
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo in (foo = 1).
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo in (foo = 1))
+"Remove this line in the final version of your proof.")
+  Info
+["replace line with:
+  We need to show that (0 = 1)."].
 Abort.
 
 (* Test 5: Unfold term in given statement that matches hypothesis,
@@ -63,7 +102,14 @@ Abort.
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo in (foo = 0).
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo in (foo = 0))
+"Remove this line in the final version of your proof.")
+  Info
+["replace line with:
+  It holds that (0 = 0)."].
 Abort.
 
 
@@ -78,13 +124,31 @@ Ltac2 Notation "Expand" "the" "definition" "of" "foo2" x(opt(seq("in", constr)))
 Goal (foo = 0) -> (foo = 2) -> (foo = 1).
 Proof.
   intros.
-  Fail Expand the definition of foo2.
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo)
+"Remove this line in the final version of your proof.")
+  Info
+["Expanded definition in statements where applicable.";
+"To include these statements, use (one of):";
+"";
+"  We need to show that (0 = 1).";
+"";
+"  It holds that (0 = 0).";
+"  It holds that (0 = 2)."].
 Abort.
 
 (* Test 7: fails to unfold term in statment without term. *)
 Goal False.
 Proof.
-  Fail Expand the definition of foo2.
+  assert_feedback_with_strings
+  (fun () =>
+  assert_fails_with_string
+  (fun () => Expand the definition of foo)
+"Remove this line in the final version of your proof.")
+  Info
+["Definition does not appear in any statement."].
 Abort.
 
 

--- a/tests/util/Assertions.v
+++ b/tests/util/Assertions.v
@@ -12,7 +12,7 @@
 (*               GNU General Public License for more details.                 *)
 (*                                                                            *)
 (*     You should have received a copy of the GNU General Public License      *)
-(*   along with Waterproof-lib. If not, see < https://www.gnu.org/licenses/>.  *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -26,28 +26,46 @@ Require Import Waterproof.Util.Assertions.
 Waterproof Enable Redirect Warnings.
 Waterproof Enable Redirect Errors.
 
+(** * Tests of the test framework *)
+
+(** ** Test for a warning *)
 Goal True.
-Proof.
-  assert_warns_with_string (fun () => warn (Message.of_string "Send a warning.")) "Send a warning.".
+assert_warns_with_string (fun () => warn (Message.of_string "Send a first warning.")) "Send a first warning.".
+Abort.
+
+(** ** Test if a warning is really thrown (and not just the last item in the log is compared) *)
+Goal True.
+warn (Message.of_string "Send a warning.").
+Fail assert_warns_with_string (fun () => ()) "Send a warning.".
+Abort.
+
+(** ** Test asserting for a failure with a given string *)
+Goal True.
+assert_fails_with_string (fun () => throw (Message.of_string "This error _should_ be raised.")) "This error _should_ be raised.".
+Abort.
+
+(** ** Test of the error message of the assert_fails_with_string tactic itself *)
+Goal True.
+assert_fails_with_string
+  (fun () => assert_fails_with_string (fun () => throw (Message.of_string "foo")) "bar")
+"The tactic failed, but with an unexpected error message. Expected:
+bar
+Got:
+foo".
+Abort.
+
+(** ** Test of the error message of the assert_warns_with_string tactic *)
+Goal True.
+assert_fails_with_string
+  (fun () => assert_warns_with_string (fun () => warn (Message.of_string "foo")) "bar")
+"The tactic warned, but with an unexpected error message. Expected:
+bar
+Got:
+foo".
 Abort.
 
 Goal True.
-Proof.
-  assert_fails_with_string (fun () => throw (Message.of_string "This error _should_ be raised.")) "This error _should_ be raised.".
-Abort.
-
-(** Test whether enabling the hypothesis flag works.
-*)
-Waterproof Enable Hypothesis Help.
-
-Goal False.
-assert_is_true (get_print_hypothesis_flag ()).
-Abort.
-
-(** Test whether disabling the hypothesis flag works.
-*)
-Waterproof Disable Hypothesis Help.
-
-Goal False.
-assert_is_false (get_print_hypothesis_flag ()).
+assert_warns_with_string (fun () => warn (Message.of_string "warning
+with line break")) "warning
+with line break".
 Abort.

--- a/tests/util/Assertions.v
+++ b/tests/util/Assertions.v
@@ -69,3 +69,10 @@ assert_warns_with_string (fun () => warn (Message.of_string "warning
 with line break")) "warning
 with line break".
 Abort.
+
+Goal True.
+assert_warns_with_strings (fun () =>
+  warn (Message.of_string "first warning");
+  warn (Message.of_string "second warning"))
+["first warning"; "second warning"].
+Abort.

--- a/tests/util/Assertions.v
+++ b/tests/util/Assertions.v
@@ -23,20 +23,21 @@ Require Import Waterproof.Util.Assertions.
 
 (* Waterproof Enable Redirect Warnings. *)
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 Waterproof Enable Redirect Errors.
 
 (** * Tests of the test framework *)
 
 (** ** Test for a warning *)
 Goal True.
-assert_warns_with_string (fun () => warn (Message.of_string "Send a first warning.")) "Send a first warning.".
+assert_feedback_with_string (fun () => warn (Message.of_string "Send a first warning.")) Warning "Send a first warning.".
 Abort.
 
 (** ** Test if a warning is really thrown (and not just the last item in the log is compared) *)
 Goal True.
 warn (Message.of_string "Send a warning.").
-Fail assert_warns_with_string (fun () => ()) "Send a warning.".
+assert_fails_with_string (fun () => assert_feedback_with_string (fun () => ()) Warning "Send a warning.")
+"The tactic was expected to warn 1 times, but it warned 0 times.".
 Abort.
 
 (** ** Test asserting for a failure with a given string *)
@@ -57,22 +58,23 @@ Abort.
 (** ** Test of the error message of the assert_warns_with_string tactic *)
 Goal True.
 assert_fails_with_string
-  (fun () => assert_warns_with_string (fun () => warn (Message.of_string "foo")) "bar")
-"The tactic warned, but with an unexpected error message. Expected:
+  (fun () => assert_feedback_with_string (fun () => warn (Message.of_string "foo")) Warning "bar")
+"The feedback message is not as expected. Expected:
 bar
 Got:
 foo".
 Abort.
 
 Goal True.
-assert_warns_with_string (fun () => warn (Message.of_string "warning
-with line break")) "warning
+assert_feedback_with_string (fun () => warn (Message.of_string "warning
+with line break")) Warning "warning
 with line break".
 Abort.
 
 Goal True.
-assert_warns_with_strings (fun () =>
+assert_feedback_with_strings (fun () =>
   warn (Message.of_string "first warning");
   warn (Message.of_string "second warning"))
+  Warning
 ["first warning"; "second warning"].
 Abort.

--- a/tests/util/MessagesToUser.v
+++ b/tests/util/MessagesToUser.v
@@ -21,9 +21,12 @@ Require Import Waterproof.Waterproof.
 Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
+Waterproof Enable Redirect Warnings.
+
 Lemma test : 0 = 0.
 Proof.
-  warn (Message.of_string "This warning _should_ be printed.").
+  warn (Message.of_string "Send a warning.");
+  assert_warning_equals_string "Send a warning.".
   Fail throw (Message.of_string "This error _should_ be raised.").
 Abort.
 
@@ -41,4 +44,15 @@ Waterproof Disable Hypothesis Help.
 
 Goal False.
 assert_is_false (get_print_hypothesis_flag ()).
+Abort.
+
+Waterproof Disable Redirect Warnings.
+
+Goal False.
+  (* TODO: this should work instead: *)
+  Fail match catch_error_message (fun () =>
+    throw (Message.of_string "error message")) with
+  | None => ()
+  | Some exn => Message.print (exn)
+  end.
 Abort.

--- a/tests/util/MessagesToUser.v
+++ b/tests/util/MessagesToUser.v
@@ -23,12 +23,12 @@ Require Import Waterproof.Util.Assertions.
 
 (* Waterproof Enable Redirect Warnings. *)
 
-Waterproof Enable Redirect Warnings.
+Waterproof Enable Redirect Feedback.
 Waterproof Enable Redirect Errors.
 
 Goal True.
 Proof.
-  assert_warns_with_string (fun () => warn (Message.of_string "Send a warning.")) "Send a warning.".
+  assert_feedback_with_string (fun () => warn (Message.of_string "Send a warning.")) Warning "Send a warning.".
 Abort.
 
 Goal True.

--- a/tests/util/MessagesToUser.v
+++ b/tests/util/MessagesToUser.v
@@ -26,16 +26,6 @@ Require Import Waterproof.Util.Assertions.
 Waterproof Enable Redirect Feedback.
 Waterproof Enable Redirect Errors.
 
-Goal True.
-Proof.
-  assert_feedback_with_string (fun () => warn (Message.of_string "Send a warning.")) Warning "Send a warning.".
-Abort.
-
-Goal True.
-Proof.
-  assert_fails_with_string (fun () => throw (Message.of_string "This error _should_ be raised.")) "This error _should_ be raised.".
-Abort.
-
 (** Test whether enabling the hypothesis flag works.
 *)
 Waterproof Enable Hypothesis Help.

--- a/tests/util/MessagesToUser.v
+++ b/tests/util/MessagesToUser.v
@@ -12,7 +12,7 @@
 (*               GNU General Public License for more details.                 *)
 (*                                                                            *)
 (*     You should have received a copy of the GNU General Public License      *)
-(*   along with Waterproof-lib. If not, see < https://www.gnu.org/licenses/>.  *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
 (*                                                                            *)
 (******************************************************************************)
 

--- a/theories/Libs/Analysis.v
+++ b/theories/Libs/Analysis.v
@@ -16,7 +16,6 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Export Libs.Analysis.ContinuityDomainNat.
 Require Export Libs.Analysis.ContinuityDomainR.
 Require Export Libs.Analysis.LimsupLiminfBolzano.
 Require Export Libs.Analysis.MetricSpaces.

--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -139,8 +139,8 @@ Definition is_continuous_in (f : ℕ → X) (a : ℕ) :=
   ((is_accumulation_point a) ∧ (limit_in_point f a (f a))) ∨ (is_isolated_point a).
 
 Theorem alt_char_continuity :
-  ∀ f : ℕ → X, ∀ a : ℕ, 
-    is_continuous_in f a ⇔ ∀ ε : R, ε > 0 ⇒ ∃ δ : R, (δ > 0) ∧ (∀ x : ℕ, 0 < | x - a | < δ ⇒ dist X (f(x)) (f(a)) < ε).
+  ∀ h : ℕ → X, ∀ a : ℕ, 
+    is_continuous_in h a ⇔ ∀ ε : R, ε > 0 ⇒ ∃ δ : R, (δ > 0) ∧ (∀ x : ℕ, 0 < | x - a | < δ ⇒ dist X (h(x)) (h(a)) < ε).
 Proof.
   Take h : (ℕ → X).
   Take a : ℕ.

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -58,8 +58,8 @@ Proof.
 Qed.
 
 Theorem alt_char_continuity :
-  ∀ f : R → R, ∀ a : R, 
-    is_continuous_in f a ⇔ ∀ ε : R, ε > 0 ⇒ ∃ δ : R, (δ > 0) ∧ (∀ x : R, 0 < | x - a | < δ ⇒ | f(x) - f(a) | < ε).
+  ∀ h : R → R, ∀ a : R, 
+    is_continuous_in h a ⇔ ∀ ε : R, ε > 0 ⇒ ∃ δ : R, (δ > 0) ∧ (∀ x : R, 0 < | x - a | < δ ⇒ | h(x) - h(a) | < ε).
 Proof.
   Take h : (R → R).
   Take a : R.

--- a/theories/Libs/Analysis/LimsupLiminfBolzano.v
+++ b/theories/Libs/Analysis/LimsupLiminfBolzano.v
@@ -57,35 +57,38 @@ Take x : ℝ.
 Qed.
 
 Lemma exists_almost_lim_sup : 
-  ∀ (a : ℕ → ℝ) (i : has_ub a) (ii : has_lb (sequence_ub a (i))) (m : ℕ) (N : ℕ),
-    ∃ k : ℕ, (N ≤ k)%nat ∧ a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (INR(m) + 1).
+  ∀ (a : ℕ → ℝ) (i : has_ub a) (ii : has_lb (sequence_ub a (i))) (m : ℕ) (N₀ : ℕ),
+    ∃ k : ℕ, (N₀ ≤ k)%nat ∧ a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (INR(m) + 1).
 Proof.
+    To show : (
+      ∀ (a : ℕ → ℝ) (i : has_ub a) (ii : has_lb (sequence_ub a (i))) (m : ℕ) (N₀ : ℕ),
+    ∃ k : ℕ, (N₀ ≤ k)%nat ∧ a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (INR(m) + 1)).
     Take a : (ℕ → ℝ).
     Assume that (has_ub a) (i).
     Assume that (has_lb (sequence_ub a (i))) (ii).
-    Take m, Nn : ℕ.
+    Take m, N₀: ℕ.
     By exists_almost_lim_sup_aux it holds that 
-      (∃ n : ℕ, (n ≥ Nn)%nat ∧ a n > sequence_ub a (i) Nn - 1 / (INR(m) + 1)).
+      (∃ n : ℕ, (n ≥ N₀)%nat ∧ a n > sequence_ub a (i) N₀ - 1 / (INR(m) + 1)).
     Obtain such an n. It holds that
-      ((n ≥ Nn)%nat ∧ a n > sequence_ub a (i) Nn - 1 / (INR(m) + 1)) (iii).
+      ((n ≥ N₀)%nat ∧ a n > sequence_ub a (i) N₀ - 1 / (INR(m) + 1)) (iii).
     Choose k := n.
     We show both statements.
-    - We need to show that (Nn ≤ k)%nat.
-      We conclude that (Nn <= k)%nat.
+    - We need to show that (N₀ ≤ k)%nat.
+      We conclude that (N₀ <= k)%nat.
     - We need to show that (a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (m + 1)).
-      We claim that (proj1_sig(_,_,lim_sup_bdd a (i) (ii)) ≤ sequence_ub a (i) Nn).
+      We claim that (proj1_sig(_,_,lim_sup_bdd a (i) (ii)) ≤ sequence_ub a (i) N₀).
       { We need to show that
           (proj1_sig(_, _, decreasing_cv (sequence_ub a (i), (Wn_decreasing a (i)), (ii))) 
-            ≤ sequence_ub a (i) Nn).
+            ≤ sequence_ub a (i) N₀).
         Define v := (decreasing_cv (sequence_ub a (i)) (Wn_decreasing a (i)) (ii)).
         clear _defeq0.
         Obtain such an l.
-        We need to show that (l ≤ sequence_ub a (i) Nn).
+        We need to show that (l ≤ sequence_ub a (i) N₀).
         By Wn_decreasing it holds that (Un_decreasing (sequence_ub a (i))).
-        By decreasing_ineq we conclude that (l <= sequence_ub a (i) Nn).
+        By decreasing_ineq we conclude that (l <= sequence_ub a (i) N₀).
       }
-      Because (iii) both (n ≥ Nn)%nat and 
-        (a n > sequence_ub a i Nn - 1 / (m + 1)) hold.
+      Because (iii) both (n ≥ N₀)%nat and 
+        (a n > sequence_ub a i N₀ - 1 / (m + 1)) hold.
       It holds that (proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1) ≤ a n) (v).
       We need to show that (proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1) < a k).
       We conclude that (& proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1) < a n = a k).
@@ -101,38 +104,38 @@ Proof.
     Assume that (has_lb (sequence_ub a (i))) (ii).
     (* TODO: notation for apply with parameters *)
     apply exists_good_subseq with (P := fun (m : ℕ) (y :ℝ) ↦ y > proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (INR(m) + 1) ).
-    Take m, N1 : nat.
-    By exists_almost_lim_sup we conclude that (there exists k : ℕ, (N1 ≤ k)%nat
+    Take m, N₀ : nat.
+    By exists_almost_lim_sup we conclude that (there exists k : ℕ, (N₀ ≤ k)%nat
       ∧ a k > proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1)).
 Qed.
 
 
 
 Lemma sequence_ub_bds :
-  ∀ (a : ℕ → ℝ) (i : has_ub a) (N : ℕ) (n : ℕ),
-    (n ≥ N)%nat ⇒ a n ≤ sequence_ub a (i) N.
+  ∀ (a : ℕ → ℝ) (i : has_ub a) (N₀ : ℕ) (n : ℕ),
+    (n ≥ N₀)%nat ⇒ a n ≤ sequence_ub a (i) N₀.
 Proof.
     Take a : (ℕ → ℝ). 
     Assume that (has_ub a) (i).
-    Take Nn, n : ℕ; such that (n ≥ Nn)%nat.
-    We need to show that (a n ≤ lub (fun k ↦ (a (Nn + k)%nat), maj_ss a Nn (i))).
+    Take N₀, n : ℕ; such that (n ≥ N₀)%nat.
+    We need to show that (a n ≤ lub (fun k ↦ (a (N₀ + k)%nat), maj_ss a N₀ (i))).
     We need to show that
-      (a n ≤ (let (a0, _) := ub_to_lub (fun k ↦ (a (Nn + k)%nat), maj_ss a Nn (i)) in a0)).
-    Define ii := (ub_to_lub (fun (k : ℕ) ↦ a (Nn +k)%nat) (maj_ss a Nn (i))).
+      (a n ≤ (let (a0, _) := ub_to_lub (fun k ↦ (a (N₀ + k)%nat), maj_ss a N₀ (i)) in a0)).
+    Define ii := (ub_to_lub (fun (k : ℕ) ↦ a (N₀ +k)%nat) (maj_ss a N₀ (i))).
     clear _defeq.
     Obtain such an M. It holds that 
-      (is_lub (EUn (fun (k : ℕ) ↦ a (Nn +k)%nat)) M).
-    It holds that (Raxioms.is_upper_bound (EUn (fun k ↦ (a (Nn + k)%nat)), M)
-      ∧ (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (Nn + k)%nat)), b) ⇨ M ≤ b)) (iii).
-    Because (iii) both (Raxioms.is_upper_bound (EUn (fun k ↦ (a (Nn + k)%nat)), M))
-      and (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (Nn + k)%nat)), b) ⇨ M ≤ b) hold.
-    It holds that (for all x : ℝ, EUn (fun k ↦ (a (Nn + k)%nat), x) ⇨ x ≤ M).
-    It holds that (Nn + (n-Nn) = n)%nat.
-    It suffices to show that (EUn (fun (k : ℕ) ↦ (a (Nn + k)%nat)) (a n)).
-    We need to show that (there exists i : ℕ, a n = a (Nn + i)%nat).
-    We need to show that (∃ i : ℕ, a n = a (Nn + i)%nat).
-    Choose k := (n - Nn)%nat.
-    We conclude that (& a n = a (Nn + n - Nn)%nat = a (Nn + k)%nat).
+      (is_lub (EUn (fun (k : ℕ) ↦ a (N₀ +k)%nat)) M).
+    It holds that (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), M)
+      ∧ (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ M ≤ b)) (iii).
+    Because (iii) both (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), M))
+      and (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ M ≤ b) hold.
+    It holds that (for all x : ℝ, EUn (fun k ↦ (a (N₀ + k)%nat), x) ⇨ x ≤ M).
+    It holds that (N₀ + (n-N₀) = n)%nat.
+    It suffices to show that (EUn (fun (k : ℕ) ↦ (a (N₀ + k)%nat)) (a n)).
+    We need to show that (there exists k : ℕ, a n = a (N₀ + k)%nat).
+    We need to show that (∃ k : ℕ, a n = a (N₀ + k)%nat).
+    Choose k := (n - N₀)%nat.
+    We conclude that (& a n = a (N₀ + n - N₀)%nat = a (N₀ + k)%nat).
 Qed.
 
 
@@ -182,6 +185,8 @@ Proof.
         (sequence_ub a (i))).
       + (* apply squeeze_theorem with (c := sequence_ub a (i))
         (a := fun (k : ℕ) ↦ L - 1 / (INR k + 1)).*)
+        To show : (for all k : ℕ,
+          L - 1 / (k + 1) <= a(n(k)) <= sequence_ub(a, i, k)).
         Take k : ℕ.
         We show both statements.
         * We need to show that (L - 1 / (k + 1) ≤ a (n k)).
@@ -239,14 +244,14 @@ Proof.
     Define ε := (x - L).
     It holds that (ε > 0).
     It holds that (∃ K : ℕ, ∀ k : ℕ, (k ≥ K)%nat ⇒ R_dist (a (n k)) x < ε).
-    Obtain such a K. Define Nn := (Nat.max K m).
-    It holds that (R_dist (a (n Nn)) x < ε).
-    By Rabs_def2 it holds that (a (n Nn) - x < ε ∧ - ε < a (n Nn) - x) (v).
-    Because (v) both (a (n Nn) - x < ε) and (- ε < a (n Nn) - x) hold.
-    It holds that (x - a (n Nn) < x - L).
-    It holds that (a (n Nn) > L).
-    By index_seq_grows_0 it holds that (n Nn ≥ Nn)%nat.
-    By sequence_ub_bds it holds that (a (n Nn) ≤ L).
+    Obtain such a K. Define N₀ := (Nat.max K m).
+    It holds that (R_dist (a (n N₀)) x < ε).
+    By Rabs_def2 it holds that (a (n N₀) - x < ε ∧ - ε < a (n N₀) - x) (v).
+    Because (v) both (a (n N₀) - x < ε) and (- ε < a (n N₀) - x) hold.
+    It holds that (x - a (n N₀) < x - L).
+    It holds that (a (n N₀) > L).
+    By index_seq_grows_0 it holds that (n N₀ ≥ N₀)%nat.
+    By sequence_ub_bds it holds that (a (n N₀) ≤ L).
     Contradiction.
 Qed.
 

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -118,7 +118,7 @@ Qed.
 Lemma one_in_complement_interval_closed_zero_open_one : (1 : ℝ \ [0,1)).
 Proof.
   We need to show that (~ ((0 <= 1) /\ (1 < 1))).
-  We conclude that (~ (& 0 <= 1 < 1)).
+  We conclude that (¬ 0 <= 1 < 1).
 Qed.
 
 #[export] Hint Resolve one_in_complement_interval_closed_zero_open_one : wp_reals.

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -123,8 +123,8 @@ Lemma conv_evt_eq_seq :
 Proof.
     Take a, b : (ℕ → ℝ) and l : ℝ.
     Assume that (evt_eq_sequences a b) (i) and (a ⟶ l).
-    We need to show that (for all ε : ℝ, ε > 0 ⇨ there exists N : ℕ,
-      for all n : ℕ, (n ≥ N)%nat ⇨ |b n - l| < ε ).
+    We need to show that (for all ε : ℝ, ε > 0 ⇨ there exists M : ℕ,
+      for all n : ℕ, (n ≥ M)%nat ⇨ |b n - l| < ε ).
     Take ε : ℝ; such that (ε > 0).
     It holds that
       (there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat ⇨ |a n - l| < ε).
@@ -166,7 +166,7 @@ Lemma lim_const_seq :
 Proof.
     Take c : ℝ.
     Define s := (constant_sequence c).
-    To show: (∀ ε : ℝ, ε > 0 ⇒ ∃ N : ℕ, ∀ n : ℕ, (n ≥ N)%nat ⇒ |(s n) - c| < ε).
+    To show: (∀ ε : ℝ, ε > 0 ⇒ ∃ Nn : ℕ, ∀ n : ℕ, (n ≥ Nn)%nat ⇒ |(s n) - c| < ε).
     Take ε : ℝ; such that (ε > 0).
     Choose Nn := O.
     Take n : ℕ; such that (n ≥ Nn)%nat.
@@ -188,9 +188,9 @@ Definition d := fun (n : ℕ) ↦ 1 / (n + 1).
 Lemma lim_d_0 : Un_cv d 0.
 Proof.
     We need to show that (Un_cv (fun n => 1 / (n + 1)) 0).
-    We need to show that (for all eps : ℝ, eps > 0 
+    We need to show that (for all ε : ℝ, ε > 0 
       ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat 
-      ⇨ ｜ 1 / (n + 1) - 0 ｜ < eps ).
+      ⇨ ｜ 1 / (n + 1) - 0 ｜ < ε ).
     Take ε : ℝ; such that (ε > 0).
     By archimed_mod it holds that (there exists n : ℕ, n > / ε).
     Obtain such an n1. Choose N := n1.
@@ -203,7 +203,6 @@ Proof.
       { We conclude that (& / ε < n1 <= n <= n + 1). }
       We conclude that (& 1 / (n + 1) - 0 = / (n + 1) < / / ε = ε).
 Qed.
-
 
 Lemma min_1_over_n_plus_1_to_0 :
   Un_cv (fun (n : ℕ) ↦ - (1 / (INR(n) + 1))) 0.
@@ -228,7 +227,7 @@ Proof.
     Take a, b, c : (ℕ ⇨ ℝ) and l : ℝ.
     Assume that (∀ n : ℕ, a n ≤ b n ∧ b n ≤ c n) and (a ⟶ l).
     Assume that (c ⟶ l).
-    To show: (∀ ε : ℝ, ε > 0 ⇒ ∃ N : ℕ, ∀ n : ℕ, (n ≥ N)%nat ⇒ |b n - l| < ε).
+    To show: (∀ ε : ℝ, ε > 0 ⇒ ∃ Nn : ℕ, ∀ n : ℕ, (n ≥ Nn)%nat ⇒ |b n - l| < ε).
     Take ε : ℝ; such that (ε > 0).
     It holds that (∃ N : ℕ, ∀ n : ℕ, (n ≥ N)%nat ⇒ |a n - l| < ε).
     Obtain such an Na.

--- a/theories/Libs/Analysis/SequentialAccumulationPoints.v
+++ b/theories/Libs/Analysis/SequentialAccumulationPoints.v
@@ -62,11 +62,11 @@ Proof.
     Take k : ℕ.
     It suffices to show that (there exists k0 : nat, a k = a k0).
     Choose k0 := k.
-    We conclude that (a k = a k0).
+    We conclude that (a k0 = a k0).
   }
-  Take n0 : ℕ.
-  By (v) it holds that (a(n n0) ≤ M).
-  It follows that (a(n n0) ≤ M).
+  Take k : ℕ.
+  By (v) it holds that (a(n k) ≤ M).
+  It follows that (a(n k) ≤ M).
 Qed.
 
 Close Scope R_scope.

--- a/theories/Libs/Analysis/Series.v
+++ b/theories/Libs/Analysis/Series.v
@@ -37,19 +37,19 @@ Waterproof Enable Automation RealsAndIntegers.
 Open Scope R_scope.
 
 Lemma sigma_split_v2 :
-  ∀ (a : ℕ → ℝ) (k l N : ℕ),
-    (k < l)%nat ⇒ (l ≤ N)%nat 
-      ⇒ sigma a k N = sigma a k (l - 1)%nat + sigma a l N.
+  ∀ (a : ℕ → ℝ) (k l M : ℕ),
+    (k < l)%nat ⇒ (l ≤ M)%nat 
+      ⇒ sigma a k M = sigma a k (l - 1)%nat + sigma a l M.
 Proof.
-    Take a : (ℕ → ℝ) and k, l, Nn : ℕ; such that
-      (k < l)%nat and (l ≤ Nn)%nat.
+    Take a : (ℕ → ℝ) and k, l, M : ℕ; such that
+      (k < l)%nat and (l ≤ M)%nat.
     It holds that (l = S (l - 1)%nat) (i).
     (* TODO: It suffices to show that (sigma a k Nn = sigma a k (l - 1) + sigma a (S (l - 1)) Nn).*)
     rewrite (i) at 2.
-    By sigma_split it suffices to show that (k <= l - 1 < Nn)%nat.
-    We show both (k <= l - 1)%nat and (l - 1 < Nn)%nat.
+    By sigma_split it suffices to show that (k <= l - 1 < M)%nat.
+    We show both (k <= l - 1)%nat and (l - 1 < M)%nat.
     - We conclude that (k ≤ l - 1)%nat.
-    - We conclude that (l - 1 < Nn)%nat.
+    - We conclude that (l - 1 < M)%nat.
 Qed.
 
 

--- a/theories/Libs/Analysis/Subsequences.v
+++ b/theories/Libs/Analysis/Subsequences.v
@@ -122,13 +122,14 @@ Proof.
     - We need to show that (is_index_seq n).
       We need to show that (is_index_seq (create_seq g)).
       By created_seq_is_index_seq it suffices to show that 
-        (for all m N : ℕ, (g m N ≥ N)%nat).
+        (for all m M : ℕ, (g m M ≥ M)%nat).
       Take m, M : nat.
       By (i) it holds that ((M ≤ g m M)%nat ∧ P m (a (g m M))).
       We conclude that (g m M >= M)%nat.
     - We need to show that (for all k : ℕ, P k (a (n k))).
       We need to show that (for all k : ℕ, P k (a ((create_seq g) k))).
-      Fail By subseq_sat_rel it suffices to show that (for all m N : ℕ, P m (a (g m N))). (*TODO: fix*)
+      Fail By subseq_sat_rel it suffices to show that
+        (for all m M : ℕ, P m (a (g m M))). (*TODO: fix*)
       apply subseq_sat_rel.
       Take m : ℕ.
       Take M : ℕ.
@@ -150,6 +151,7 @@ Proof.
     Assume that (∀ k : ℕ, (g k ≤ g (S k))%nat).
     Take k : ℕ. 
     induction l as [|l IH_l].
+    Check k.
 
     (** We first need to show that if $k \leq 0$ then $(f (k) \leq f(0))$.*)
     Assume that (k ≤ 0)%nat.

--- a/theories/Libs/Analysis/Subsequences.v
+++ b/theories/Libs/Analysis/Subsequences.v
@@ -107,7 +107,7 @@ Qed.
 
 Lemma exists_good_subseq :
   ∀ (a : ℕ → ℝ) (P : ℕ → ℝ → Prop),
-    (∀ (m : ℕ) (N : ℕ), ∃ k : ℕ, (N ≤ k)%nat ∧ (P m (a k))) ⇒
+    (∀ (m : ℕ) (N₀ : ℕ), ∃ k : ℕ, (N₀ ≤ k)%nat ∧ (P m (a k))) ⇒
       ∃ n : ℕ → ℕ, is_index_seq n ∧ ∀ k : ℕ, P k (a (n k)).
 Proof.
     Take a : (ℕ → ℝ).
@@ -132,6 +132,7 @@ Proof.
         (for all m M : ℕ, P m (a (g m M))). (*TODO: fix*)
       apply subseq_sat_rel.
       Take m : ℕ.
+      We need to show that (for all M : ℕ, P(m, a (g(m, M)))).
       Take M : ℕ.
       By (i) it holds that ((M ≤ g m M)%nat ∧ P m (a (g m M))) (ii).
       Because (ii) both (M ≤ g m M)%nat and (P m (a (g m M))) hold.
@@ -151,8 +152,6 @@ Proof.
     Assume that (∀ k : ℕ, (g k ≤ g (S k))%nat).
     Take k : ℕ. 
     induction l as [|l IH_l].
-    Check k.
-
     (** We first need to show that if $k \leq 0$ then $(f (k) \leq f(0))$.*)
     Assume that (k ≤ 0)%nat.
     It holds that (k = 0)%nat.

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -152,7 +152,7 @@ Lemma upp_bd_set_to_low_bd_set_opp :
 Proof.
     Take A : (ℝ → Prop) and M : ℝ.
     Assume that (M is an upper bound for A) (i).
-    We need to show that (∀ a : ℝ, (set_opp A a) ⇒ -M ≤ a).
+    We need to show that (∀ b : ℝ, (set_opp A b) ⇒ -M ≤ b).
     Take b : ℝ. Assume that (set_opp A b).
     Define a := (-b).
     It holds that (A a).
@@ -274,6 +274,9 @@ Lemma exists_inf :
     exists (m : ℝ), is_inf A m.
 Proof.
     Take A : (ℝ → Prop).
+    To show : (for all z : ℝ,
+      A(z) ⇨ A is _bounded from below_ ⇨ there exists m : ℝ,
+      m is the _infimum_ of A).
     Take z : ℝ. Assume that (A z).
     Assume that (is_bounded_below A) (vi).
     Define B := (set_opp A).
@@ -734,16 +737,20 @@ Lemma exists_almost_lim_sup_aux :
     ∃ k : ℕ, (k ≥ N)%nat ∧ a k > sequence_ub a pr N - 1 / (INR(m) + 1).
 Proof.
     Take a : (ℕ → ℝ).
+    To show :
+      (forall (pr : has_ub(a)) (m Nn : ℕ),
+      there exists k : ℕ,
+      (k ≥ Nn)%nat ∧ a(k) > sequence_ub(a, pr, Nn) - 1 / (m + 1)).
     Assume that (has_ub a) (i).
     Take m, Nn : ℕ.
     By seq_ex_almost_maximizer_m it holds that
       (∃ k : ℕ, a (Nn + k)%nat > sequence_ub a (i) Nn - 1 / (INR m + 1)).
-    Obtain such a k. Choose l := (Nn+k)%nat.
+    Obtain such a k. Choose k0 := (Nn+k)%nat.
     We show both statements.
-    - We need to show that (l ≥ Nn)%nat.
-      We conclude that (l ≥ Nn)%nat.
-    - We need to show that ( a l > sequence_ub a (i) Nn - 1 / (m + 1) ).
-      We conclude that ( a l > sequence_ub a (i) Nn - 1 / (m + 1) ).
+    - We need to show that (k0 ≥ Nn)%nat.
+      We conclude that (k0 ≥ Nn)%nat.
+    - We need to show that ( a k0 > sequence_ub a (i) Nn - 1 / (m + 1) ).
+      We conclude that ( a k0 > sequence_ub a (i) Nn - 1 / (m + 1) ).
 Qed.
 
 #[export] Hint Resolve bounded_by_upper_bound_propform : wp_reals.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -82,9 +82,8 @@ The variable has been renamed."])
       match Constr.has_evar t with
       | true => 
         rename_blank_evars_in_term (Ident.to_string s) t;
-        
-        warn (concat_list [of_string "Please come back to this line later to make a definite choice for "; of_ident s; of_string ".
-For now you can use that "; of_constr constr:($v = $t); of_string "."])
+        warn (concat_list [of_string "Please come back to this line to make a definitive choice for "; of_ident s; of_string "."; fnl ();
+        of_string "For now you can use that "; of_constr constr:($v = $t)])
       | _ => ()
       end;
       exists $v;      
@@ -92,6 +91,10 @@ For now you can use that "; of_constr constr:($v = $t); of_string "."])
       
     | [ |- _ ] => throw (of_string "`Choose` can only be applied to 'exists' goals.")
   end.
+
+Ltac2 Eval String.equal ("Please come back to this line to make a definitive choice for n.
+For now you can use that n = ?m") "Please come back to this line to make a definitive choice for n.
+For now you can use that n = ?m".
 
 (**
   Instantiate a variable in an [exists] [goal], according to a given [constr], without renaming said [constr]. The [constr] can contain blanks, which are filled in

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -92,10 +92,6 @@ The variable has been renamed."])
     | [ |- _ ] => throw (of_string "`Choose` can only be applied to 'exists' goals.")
   end.
 
-Ltac2 Eval String.equal ("Please come back to this line to make a definitive choice for n.
-For now you can use that n = ?m") "Please come back to this line to make a definitive choice for n.
-For now you can use that n = ?m".
-
 (**
   Instantiate a variable in an [exists] [goal], according to a given [constr], without renaming said [constr]. The [constr] can contain blanks, which are filled in
   with freshly named evars, so that the user can refer to them later.

--- a/theories/Tactics/Help.v
+++ b/theories/Tactics/Help.v
@@ -28,7 +28,6 @@ Require Import Util.MessagesToUser.
 
 Require Import Waterprove.
 
-
 Local Ltac2 goal_impl_msg (premise: constr) :=
   concat_list [of_string "The goal is to show an implication (⇒).
 Assume the premise "; of_constr premise; of_string ", use

--- a/theories/Util/Assertions.v
+++ b/theories/Util/Assertions.v
@@ -16,6 +16,26 @@
 (*                                                                            *)
 (******************************************************************************)
 
+(**
+* Waterproof test framework
+
+This file contains the Waterproof test framework.
+
+To use the framework, import it with
+[Require Import Waterproof.Util.Assertions].
+
+Note that for writing tests for the output of Waterproof tactics,
+it can be useful to first write on the top of the file:
+[
+Waterproof Enable Logging.
+]
+After writing all the tests, this line should be replaced by
+[
+Waterproof Enable Redirect Feedback.
+]
+otherwise feedback shows up during compilation of the library.
+*)
+
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Int.
 Require Import Ltac2.Message.
@@ -32,7 +52,7 @@ Ltac2 mutable test_verbosity () := 0.
 
 Ltac2 Type exn ::= [ TestFailedError(message) ].
 
-Ltac2 fail_test (msg:message) := 
+Ltac2 fail_test (msg:message) :=
   Control.zero (TestFailedError msg).
 
 Definition type_of_test_aux {T : Type} (x : T) := T.
@@ -43,8 +63,8 @@ Definition type_of_test_aux {T : Type} (x : T) := T.
   Arguments:
     - [msg : message] The message to print on success.
 *)
-Ltac2 print_success (msg : message) := 
-  match (ge (test_verbosity ()) 1) with 
+Ltac2 print_success (msg : message) :=
+  match (ge (test_verbosity ()) 1) with
     |  false => ()
     |  _ => print msg
   end.
@@ -54,15 +74,15 @@ Ltac2 print_success (msg : message) :=
 
   Arguments:
     - f, function without arguments.
-    
+
   Raises Exceptions:
     - TestFailedError, if the execution of "f" does **not** raise a catchable exception.
 *)
 Ltac2 assert_raises_error f :=
   match Control.case f with
     | Val _ => fail_test (of_string "Should raise an error")
-    | Err exn => print_success (concat 
-      (of_string "Test passed, got error:") 
+    | Err exn => print_success (concat
+      (of_string "Test passed, got error:")
       (of_exn exn))
   end.
 
@@ -92,15 +112,11 @@ Ltac2 assert_fails_with_string (tac : unit -> 'a) (expected_string : string) :=
     | RedirectedToUserError msg => inner_msg_test msg
     | TestFailedError msg => inner_msg_test msg
     (** TODO: add more possible errors here *)
-    | e => 
+    | e =>
       let msg := Message.of_exn e in
       inner_msg_test msg
     end
   end.
-
-
-
-
 
 Ltac2 feedback_verb_infinitive (lvl : FeedbackLevel) :=
   match lvl with
@@ -120,6 +136,18 @@ Ltac2 feedback_verb_past_tense (lvl : FeedbackLevel) :=
   | Error => "sent an error message"
   end.
 
+(**
+  Asserts that [n] feedback messages are produced at feedback level [lvl]
+  by executing the tactic [tac]
+
+  Arguments:
+  - tac, the tactic to execute
+  - lvl, the feedback level
+  - n, the number of feedback messages expected
+
+  Raises Fatal Exceptions:
+  - TestFailedError, if the tactic produces a different number of feedback messages than expected.
+*)
 Ltac2 assert_feedback_n (tac : unit -> 'a) (lvl : FeedbackLevel) (n : int) :=
   let length_before := List.length (get_feedback_log lvl) in
   tac ();
@@ -138,14 +166,25 @@ Ltac2 assert_feedback_n (tac : unit -> 'a) (lvl : FeedbackLevel) (n : int) :=
   Assert that the execution of the tactic does not produce a warning
 
   Arguments:
-  - tac, the tactic to execute
+    - tac, the tactic to execute
 
   Raises Fatal Exceptions:
-  - TestFailedError, if the tactic produces a warning.
+    - TestFailedError, if the tactic produces a warning.
 *)
 Ltac2 assert_no_feedback (tac : unit -> 'a) (lvl : FeedbackLevel) :=
   assert_feedback_n tac lvl 0.
 
+(**
+  Asserts that a feedback message [msg] after converting to a string
+  is as expected.
+
+  Arguments:
+    - expected_string, the expected feedback message
+    - msg, the feedback message
+
+  Raises Fatal Exceptions:
+    - TestFailedError, if the feedback message is not as expected.
+*)
 Ltac2 assert_feedback_string_equals (expected_string : string) (msg : message) :=
   if String.equal (Message.to_string msg) expected_string then
     print_success (of_string ("The feedback message is as expected"))
@@ -153,6 +192,18 @@ Ltac2 assert_feedback_string_equals (expected_string : string) (msg : message) :
     fail_test (concat_list [of_string "The feedback message is not as expected. Expected:"; fnl (); of_string expected_string; fnl ();
     of_string "Got:"; fnl (); msg]).
 
+(**
+  Asserts that the feedback messages produced by the tactic at a
+  given feedback level are as expected.
+
+  Arguments:
+    - tac, the tactic to execute
+    - lvl, the feedback level
+    - expected_strings, the expected feedback messages
+
+  Raises Fatal Exceptions:
+    - TestFailedError, if the feedback messages are not as expected.
+*)
 Ltac2 assert_feedback_with_strings (tac : unit -> 'a) (lvl : FeedbackLevel)
     (expected_strings : string list) :=
   assert_feedback_n (tac) lvl (List.length expected_strings);
@@ -193,8 +244,8 @@ Ltac2 assert_feedback (tac : unit -> 'a) (lvl : FeedbackLevel) :=
     print_success (concat_list [of_string ("The tactic "); of_string (feedback_verb_past_tense lvl)]).
 
 (**
-  Checks if two lists (of arbitrary type) are equal. 
-  
+  Checks if two lists (of arbitrary type) are equal.
+
   Raises an error if they have different lengths, or that there exists an index such that their value at that index differs.
 
   Arguments:
@@ -204,7 +255,7 @@ Ltac2 assert_feedback (tac : unit -> 'a) (lvl : FeedbackLevel) :=
     - TestFailedError, if x and y have a different length.
     - TestFailedError, if there exists an i such that x[i] ≠ y[i].
 *)
-Ltac2 rec assert_list_equal (f : 'a -> 'a -> bool) (of_a : 'a -> message) (x:'a list) (y: 'a list) :=    
+Ltac2 rec assert_list_equal (f : 'a -> 'a -> bool) (of_a : 'a -> message) (x:'a list) (y: 'a list) :=
   match x with
     | x_head::x_tail =>
       match y with
@@ -212,15 +263,15 @@ Ltac2 rec assert_list_equal (f : 'a -> 'a -> bool) (of_a : 'a -> message) (x:'a 
           match (f x_head y_head) with
             | true => assert_list_equal f of_a x_tail y_tail
             | false =>
-              fail_test 
-                (concat 
-                  (of_string "Unequal elements:") 
+              fail_test
+                (concat
+                  (of_string "Unequal elements:")
                   (concat (of_a x_head) (of_a y_head))
                 )
           end
         | [] => fail_test (of_string "First list has more elements")
       end
-    | [] => 
+    | [] =>
       match y with
         | [] => print_success (of_string "Test passed: lists indeed equal")
         | y_head::y_tai => fail_test (of_string "Second list has more elements")
@@ -264,15 +315,15 @@ Ltac2 assert_hyp_has_type (h: ident) (t: constr) :=
         (concat (of_string "Hypothesis '") (of_ident h))
         (concat (of_string "' indeed has type: ") (of_constr t))
       )
-  
+
     | false =>
       fail_test (concat
         (concat
-          (of_string "Hypothesis has wrong type. Expected type: ") 
+          (of_string "Hypothesis has wrong type. Expected type: ")
           (of_constr t)
         )
         (concat
-          (of_string ", actual type: ") 
+          (of_string ", actual type: ")
           (of_constr (eval cbv in (type_of_test_aux $h_val)))
         )
       )
@@ -327,13 +378,13 @@ Ltac2 assert_is_false (b:bool) :=
   end.
 
 Local Ltac2 rec string_equal_rec (idx) (s1:string) (s2:string) :=
-  (* If the strings are of unequal length, 
+  (* If the strings are of unequal length,
       then they are never equal*)
   let len1 := (String.length s1) in
   let len2 := (String.length s2) in
   match Int.equal len1 len2 with
     | false => false
-    | true => 
+    | true =>
       (* If we are past the last index of the strings,
       then stop and return "true".
       Otherwise, compare the integer representation
@@ -397,7 +448,7 @@ Ltac2 assert_goal_is (target:constr) :=
 
 (**
   Checks if the type of a term corresponds to an expected type.
-    
+
   Arguments:
     - [term : constr] the term to determine the type of
     - [expected_type : constr] the expected type
@@ -409,7 +460,7 @@ Ltac2 assert_type_equal (term:constr) (expected_type:constr) :=
   match (Constr.equal (eval cbv in (type_of $term)) (eval cbv in $expected_type)) with
     | true => print_success (of_string "Type is as expected")
     | false =>
-      fail_test (concat 
+      fail_test (concat
         (concat
           (of_string "Type not as expected, got: ")
           (of_constr (eval cbv in (type_of $term)))

--- a/theories/Util/Assertions.v
+++ b/theories/Util/Assertions.v
@@ -130,7 +130,8 @@ Ltac2 assert_feedback_n (tac : unit -> 'a) (lvl : FeedbackLevel) (n : int) :=
   else
     fail_test (concat_list [of_string "The tactic was expected to ";
     of_string (feedback_verb_infinitive lvl) ; of_string " ";
-    of_int n; of_string " times, but it warned ";
+    of_int n; of_string " times, but it ";
+    of_string (feedback_verb_past_tense lvl); of_string " ";
     of_int (Int.sub length_after length_before); of_string " times."]).
 
 (**

--- a/theories/Util/MessagesToUser.v
+++ b/theories/Util/MessagesToUser.v
@@ -19,9 +19,19 @@
 Require Export Ltac2.Ltac2.
 Require Import Ltac2.Bool.
 Require Import Ltac2.Init.
+Require Import Ltac2.String.
 
 Require Import Waterproof.Waterproof.
+Require Import Waterproof.Util.Assertions.
 
 Ltac2 @ external warn: message -> unit := "coq-waterproof" "warn_external".
 Ltac2 @ external throw: message -> unit := "coq-waterproof" "throw_external".
 Ltac2 @ external get_print_hypothesis_flag: unit -> bool := "coq-waterproof" "get_print_hypothesis_flag_external".
+Ltac2 @ external get_last_warning : unit -> message option := "coq-waterproof" "get_last_warning_external".
+Ltac2 @ external catch_error_message : (unit -> 'a) -> message option := "coq-waterproof" "catch_error_return_message_external".
+
+Ltac2 assert_warning_equals_string (str : string) :=
+  match get_last_warning () with
+  | Some msg => assert_is_true (String.equal (Message.to_string msg) str)
+  | None => throw (Message.of_string "No warning was raised.")
+  end.

--- a/theories/Util/MessagesToUser.v
+++ b/theories/Util/MessagesToUser.v
@@ -73,6 +73,8 @@ Ltac2 warn (msg : message) :=
 Ltac2 get_feedback_log (lvl : FeedbackLevel) :=
   get_feedback_log_external (feedback_lvl_to_ffi lvl).
 
+Ltac2 print (msg : message) := inform msg.
+
 (* Note, there could arise a use case for sending an error on the feedback channel without
   actually raising an error, but it could also be confusing. For now, errors are therefore
   handled through a different channel *)

--- a/theories/Util/MessagesToUser.v
+++ b/theories/Util/MessagesToUser.v
@@ -29,6 +29,8 @@ Ltac2 fnl () := Message.of_string "
 
 Ltac2 @ external warn: message -> unit := "coq-waterproof" "warn_external".
 Ltac2 @ external throw_external: message -> unit := "coq-waterproof" "throw_external".
+Ltac2 @ external notice : message -> unit := "coq-waterproof" "notice_external".
+Ltac2 @ external inform : message -> unit := "coq-waterproof" "inform_external".
 Ltac2 @ external get_print_hypothesis_flag: unit -> bool := "coq-waterproof" "get_print_hypothesis_flag_external".
 Ltac2 @ external get_redirect_errors_flag : unit -> bool := "coq-waterproof" "get_redirect_errors_flag_external".
 


### PR DESCRIPTION
# Add functionality to test messages and errors.

The core new functions are `assert_fails_with_string` and `assert_feedback_with_strings`.

## Example usage:

```
assert_feedback_with_strings (fun () =>
  warn (Message.of_string "first warning");
  warn (Message.of_string "second warning"))
  Warning
["first warning"; "second warning"].
```

```
assert_fails_with_string
  (fun () => throw (Message.of_string "This error _should_ be raised."))
  "This error _should_ be raised.".
```

## In addition

We also added more channels for feedback (inform, notice ...) and added a possibility for logging general feedback.
We have removed all warnings during library compilation.