### PR TITLE
Feat obtain multiple vars + warn on unexpected variable names.

### DIFF
--- a/_CoqProjectForMake
+++ b/_CoqProjectForMake
@@ -70,6 +70,7 @@ theories/Tactics/ToShow.v
 theories/Tactics/Unfold.v
 
 theories/Util/Assertions.v
+theories/Util/Binders.v
 theories/Util/Constr.v
 theories/Util/Evars.v
 theories/Util/Goals.v

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -25,6 +25,8 @@ Require Import Waterproof.Tactics.
 Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
+Waterproof Enable Redirect Feedback.
+
 (** Test 0: This should choose m equal to n *)
 Goal forall n : nat, exists m : nat, n = m.
 Proof.
@@ -61,12 +63,10 @@ Goal forall n : nat, ( ( (n = n) \/ (n + 1 = n + 1) ) -> (n + 1 = n + 1)).
     Fail Choose m := n.
 Abort.
 
-Waterproof Enable Redirect Feedback.
-
 (** Test 5: Choose a blank *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
-(String.concat "" ["Please come back to this line to make a definitive choice for n.
+(String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
 (n = ?n)."]).
 Abort.
@@ -74,7 +74,7 @@ Abort.
 (** Test 6: Choose a named evar *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (?[m])) Warning
-(String.concat "" ["Please come back to this line to make a definitive choice for n.
+(String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
 (n = ?m)."]).
 Abort.
@@ -82,7 +82,7 @@ Abort.
 (** Test 7: Choose a blank check that blank was renamed *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
-(String.concat "" ["Please come back to this line to make a definitive choice for n.
+(String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
 (n = ?n)."]).
     assert (?n = 0).
@@ -91,20 +91,25 @@ Abort.
 (** Test 8: Choose a more complicated blank and check that renaming took place,
     by reformulating the goal in terms of the new named evars. *)
 Goal exists n : nat, n + 1 = n + 1.
-    Choose n := (_ + _ + _).
+    assert_feedback_with_string (fun () => Choose n := (_ + _ + _)) Warning
+(String.concat "" ["Please come back later to make a definitive choice for n.
+For now you can use that "; "
+(n = ?n + ?n0 + ?n1)."]).
     change (?n + ?n0 + ?n1 + 1 = ?n + ?n0 + ?n1 + 1).
 Abort.
 
 (** Test 9: Choose a blank without specifying the name of the variable *)
 Goal exists n : nat, n + 1 = n + 1.
-  Choose (_).
+  assert_feedback_with_string (fun () => Choose (_)) Warning
+"Please come back later to make a definite choice.".
   change (?n + 1 = ?n + 1).
 Abort.
 
 (** Test 10: Choose a blank if binder has no name *)
 Goal exists _ : nat, True.
 Proof.
-  Choose (_).
+  assert_feedback_with_string (fun () => Choose (_)) Warning
+"Please come back later to make a definite choice.".
   (* In this case, the blank evar should be renamed to `x` *)
   assert (?x = 0). (* This checks if ?x exists and can be referred to. *)
 Abort.
@@ -114,22 +119,14 @@ Abort.
 (** Test 11: Warn on different variable name *)
 Goal exists n : nat, n + 1 = n + 1.
 Proof.
-    Choose m := 1.
+    assert_feedback_with_strings (fun () => Choose m := 1) Warning
+["Expected variable name n instead of m."].
 Abort.
 
-(** Test 12: Warn on different variable name when binder is shielded,
+(** Test 12: Do not warn on different variable name when binder is shielded,
     because of an already existing definition. *)
 Goal exists n : nat, n + 1 = n + 1.
 Proof.
     set (n := 3).
-    Choose n0 := 2.
-Abort.
-
-(** Test 12: Warn on different variable name when binder is shielded,
-    because of an already existing definition, using that already
-    defined variable *)
-Goal exists n : nat, n + 1 = n + 1.
-Proof.
-    set (n := 3).
-    Choose n0 := n.
+    assert_no_feedback (fun () => Choose n0 := 2) Warning.
 Abort.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -66,29 +66,29 @@ Waterproof Enable Redirect Feedback.
 (** Test 5: Choose a blank *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
-"Please come back to this line to make a definitive choice for n.
-For now you can use that 
-(n = ?n)".
+(String.concat "" ["Please come back to this line to make a definitive choice for n.
+For now you can use that "; "
+(n = ?n)."]).
 Abort.
 
 (** Test 6: Choose a named evar *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (?[m])) Warning
-"Please come back to this line to make a definitive choice for n.
-For now you can use that 
-(n = ?m)".
+(String.concat "" ["Please come back to this line to make a definitive choice for n.
+For now you can use that "; "
+(n = ?m)."]).
 Abort.
 
 (** Test 7: Choose a blank check that blank was renamed *)
 Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
-"Please come back to this line to make a definitive choice for n.
-For now you can use that 
-(n = ?n)".
+(String.concat "" ["Please come back to this line to make a definitive choice for n.
+For now you can use that "; "
+(n = ?n)."]).
     assert (?n = 0).
 Abort.
 
-(** Test 8: Choose a more complicated blank and check that renaming took place, 
+(** Test 8: Choose a more complicated blank and check that renaming took place,
     by reformulating the goal in terms of the new named evars. *)
 Goal exists n : nat, n + 1 = n + 1.
     Choose n := (_ + _ + _).

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -70,7 +70,7 @@ Proof.
 Abort.
 
 
-(** Test 5: whether original hypothesis is destructed, so if the goal depends on the 
+(** Test 5: whether original hypothesis is destructed, so if the goal depends on the
       specific term of the sigma type, the goal changes as well.
       As one would expect when using 'destruct .. as [.. ..]'. *)
 Goal forall p : {n : nat | (n + 1 = n)%nat}, (proj1_sig p = 0)%nat.
@@ -111,10 +111,24 @@ Proof.
 Abort.
 
 
-(** Test 9: throws error if variable name is 'Qed' 
+(** Test 9: throws error if variable name is 'Qed'
     (quick fix for Waterproof editor / Coq lsp)  *)
 Goal (exists n : nat, n + 1 = n)%nat -> False.
 Proof.
   intro i.
   Fail Obtain such Qed.
+Abort.
+
+(** Test 10: obtain multiple variables *)
+Goal (exists n m : nat, n + 1 = m)%nat -> True.
+Proof.
+  intro H.
+  Obtain n, m according to (H).
+Abort.
+
+(** Test 11: obtain multiple variables *)
+Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
+Proof.
+  intro H.
+  Obtain such n, m, k, l.
 Abort.

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -32,7 +32,10 @@ Require Import Max.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
+
+Waterproof Enable Redirect Feedback.
 
 (** Test 0: works with existence statement*)
 Goal (exists n : nat, n + 1 = n)%nat -> False.
@@ -107,7 +110,7 @@ Proof.
     intro.
     intro.
     pose (H0 eps H1).
-    Obtain such an N1.
+    Obtain such an N.
 Abort.
 
 
@@ -140,14 +143,17 @@ Abort.
 Goal (exists n : nat, n = 0)%nat -> True.
 Proof.
   intro H.
-  Obtain such an m.
+  assert_feedback_with_string (fun () => Obtain such an m) Warning
+"Expected variable name n instead of m.".
 Abort.
 
 (** Test 13: obtain with multiple wrong variable names *)
 Goal (exists n m: nat, n = m)%nat -> True.
 Proof.
   intro H.
-  Obtain such k, l.
+  assert_feedback_with_strings (fun () => Obtain such k, l) Warning
+["Expected variable name n instead of k.";
+"Expected variable name m instead of l."].
 Abort.
 
 (** Test 14 : obtain but with a wrong variabl ename, later
@@ -155,7 +161,8 @@ Abort.
 Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
 Proof.
   intro H.
-  Obtain such an n, k.
+  assert_feedback_with_strings (fun () => Obtain such an n, k) Warning
+["Expected variable name m instead of k."].
 Abort.
 
 (** Test 15 : obtain when the variable has been visibly renamed *)
@@ -163,12 +170,13 @@ Goal (exists n : nat, n = 0)%nat -> True.
 Proof.
   intro H.
   set (n := 3).
-  Obtain n0 according to (H).
+  assert_no_feedback (fun () => Obtain n0 according to (H)) Warning.
 Abort.
 
 (** Test 16: obtain when wrongly using a previous variable *)
 Goal (exists n m : nat, n = m)%nat -> True.
 Proof.
   intro H.
-  Obtain such m, m0.
+  assert_feedback_with_strings (fun () => Obtain such m, m0) Warning
+["Expected variable name n instead of m."].
 Abort.

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -132,3 +132,43 @@ Proof.
   intro H.
   Obtain such n, m, k, l.
 Abort.
+
+(** TODO: we should actually test for warnings below,
+    once the branch on testing warnings and errors is merged. *)
+
+(** Test 12 : obtain but with a wrong variable name *)
+Goal (exists n : nat, n = 0)%nat -> True.
+Proof.
+  intro H.
+  Obtain such an m.
+Abort.
+
+(** Test 13: obtain with multiple wrong variable names *)
+Goal (exists n m: nat, n = m)%nat -> True.
+Proof.
+  intro H.
+  Obtain such k, l.
+Abort.
+
+(** Test 14 : obtain but with a wrong variabl ename, later
+  in the string *)
+Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
+Proof.
+  intro H.
+  Obtain such an n, k.
+Abort.
+
+(** Test 15 : obtain when the variable has been visibly renamed *)
+Goal (exists n : nat, n = 0)%nat -> True.
+Proof.
+  intro H.
+  set (n := 3).
+  Obtain n0 according to (H).
+Abort.
+
+(** Test 16: obtain when wrongly using a previous variable *)
+Goal (exists n m : nat, n = m)%nat -> True.
+Proof.
+  intro H.
+  Obtain such m, m0.
+Abort.

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -133,7 +133,7 @@ Abort.
 Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
 Proof.
   intro H.
-  Obtain such n, m, k, l.
+  Obtain such n, m, m0, l.
 Abort.
 
 (** TODO: we should actually test for warnings below,
@@ -179,4 +179,39 @@ Proof.
   intro H.
   assert_feedback_with_strings (fun () => Obtain such m, m0) Warning
 ["Expected variable name n instead of m."].
+Abort.
+
+(** Test 17 : Check that intermediate hypotheses are deleted *)
+Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
+Proof.
+  intro H.
+  Obtain such n, m, k, l.
+  Fail Check _H0.
+Abort.
+
+Waterproof Enable Redirect Errors.
+
+(** Test 19: Try to obtain too many variables *)
+Goal (exists n m : nat, n = m)%nat -> True.
+Proof.
+  intro H.
+  assert_fails_with_string (fun () => Obtain such n, m, k)
+"Couldn't obtain k.
+There aren't enough variables to obtain.".
+Abort.
+
+(** Test 20: Test that the correct variable has been renamed *)
+Goal (exists n : nat, n = 0)%nat -> True.
+Proof.
+  intro H.
+  Obtain such an n.
+  assert (n = 0)%nat by exact _H.
+  assert (exists n0 : nat, n0 = 0)%nat by exact H.
+Abort.
+
+(** Test 21: The indicated statement is not a "there exists..." statement*)
+Goal (forall n : nat, n = 0)%nat -> True.
+  intro H.
+  assert_fails_with_string (fun () => Obtain n according to (H))
+"Can only obtain variables from 'there exists...' statements.".
 Abort.

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -43,7 +43,7 @@ Goal forall n : nat, n <= 2*n.
     Fail Take n : bool.
 Abort.
 
-(** Test 3: This should raise an error, 
+(** Test 3: This should raise an error,
     because [Take] solves forall-quatifiers *)
 Goal exists n : nat, n <= 2*n.
     Fail Take n : nat.
@@ -98,7 +98,7 @@ Goal forall (n m k: nat) (b1 b2: bool), Nat.odd (n + m + k) = andb b1 b2.
 Abort.
 
 (** Test 8: look how crazy many vars we can introduce*)
-Goal forall (a b c d e f g: nat) (b1 b2: bool), 
+Goal forall (a b c d e f g: nat) (b1 b2: bool),
     Nat.odd (a + b + c + d + e + f + g) = andb b1 b2.
     Take a, b, c, d, e, f, g : nat and b1, b2: bool.
 Abort.
@@ -109,7 +109,7 @@ Abort.
     Currently it raises "Internal (err:(a is already used.))"
     which seems clear enough :)
     *)
-Goal forall (a b c d e f g: nat) (b1 b2: bool), 
+Goal forall (a b c d e f g: nat) (b1 b2: bool),
     Nat.odd (a + b + c + d + e + f + g) = andb b1 b2.
     assert_fails_with_string (fun() => Take a, b, c, d, e, f, g : nat and a, h: bool)
 "Internal (err:(a is already used.))".
@@ -135,7 +135,7 @@ Goal not (0 = 1).
 Abort.
 
 Require Import Coq.Reals.Reals.
-(** Test 13: Introducing too many variables when 
+(** Test 13: Introducing too many variables when
     the for all statement is followed by an implication.
 *)
 Goal forall (n : nat) (x y : R), (0 < x < y)%R -> (x^n < y^n)%R.
@@ -162,7 +162,7 @@ Proof.
 "Expected variable name n0 instead of m.".
 Abort.
 
-(** Test 16: Do not warn if variable has visually been renamed (although 
+(** Test 16: Do not warn if variable has visually been renamed (although
     internally, the binder name stays the same) *)
 Goal forall n : nat, n = n.
 Proof.
@@ -187,7 +187,7 @@ Proof.
   assert_no_feedback (fun () => Take n0 : nat) Warning.
 Abort.
 
-(** Test 19: If a statement reuses a same binder name, and 
+(** Test 19: If a statement reuses a same binder name, and
     variable are introduced one by one, go with the
     visually rename binder. *)
 Goal forall n : nat, forall n : nat, n = n.

--- a/theories/Libs/Analysis/LimsupLiminfBolzano.v
+++ b/theories/Libs/Analysis/LimsupLiminfBolzano.v
@@ -34,8 +34,8 @@ Waterproof Enable Automation RealsAndIntegers.
 Open Scope R_scope.
 
 (** ## lim sup*)
-Definition lim_sup_bdd (a : ℕ → ℝ) 
-                       (pr1 : has_ub a) 
+Definition lim_sup_bdd (a : ℕ → ℝ)
+                       (pr1 : has_ub a)
                        (pr2 : has_lb (sequence_ub a pr1))
 := decreasing_cv (sequence_ub a pr1) (Wn_decreasing a pr1) (pr2).
 
@@ -56,7 +56,7 @@ Take x : ℝ.
       By lim_d_0 we conclude that (Un_cv d 0).
 Qed.
 
-Lemma exists_almost_lim_sup : 
+Lemma exists_almost_lim_sup :
   ∀ (a : ℕ → ℝ) (i : has_ub a) (ii : has_lb (sequence_ub a (i))) (m : ℕ) (N₀ : ℕ),
     ∃ k : ℕ, (N₀ ≤ k)%nat ∧ a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (INR(m) + 1).
 Proof.
@@ -67,7 +67,7 @@ Proof.
     Assume that (has_ub a) (i).
     Assume that (has_lb (sequence_ub a (i))) (ii).
     Take m, N₀: ℕ.
-    By exists_almost_lim_sup_aux it holds that 
+    By exists_almost_lim_sup_aux it holds that
       (∃ n : ℕ, (n ≥ N₀)%nat ∧ a n > sequence_ub a (i) N₀ - 1 / (INR(m) + 1)).
     Obtain such an n. It holds that
       ((n ≥ N₀)%nat ∧ a n > sequence_ub a (i) N₀ - 1 / (INR(m) + 1)) (iii).
@@ -78,7 +78,7 @@ Proof.
     - We need to show that (a k > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (m + 1)).
       We claim that (proj1_sig(_,_,lim_sup_bdd a (i) (ii)) ≤ sequence_ub a (i) N₀).
       { We need to show that
-          (proj1_sig(_, _, decreasing_cv (sequence_ub a (i), (Wn_decreasing a (i)), (ii))) 
+          (proj1_sig(_, _, decreasing_cv (sequence_ub a (i), (Wn_decreasing a (i)), (ii)))
             ≤ sequence_ub a (i) N₀).
         Define v := (decreasing_cv (sequence_ub a (i)) (Wn_decreasing a (i)) (ii)).
         clear _defeq0.
@@ -87,7 +87,7 @@ Proof.
         By Wn_decreasing it holds that (Un_decreasing (sequence_ub a (i))).
         By decreasing_ineq we conclude that (l <= sequence_ub a (i) N₀).
       }
-      Because (iii) both (n ≥ N₀)%nat and 
+      Because (iii) both (n ≥ N₀)%nat and
         (a n > sequence_ub a i N₀ - 1 / (m + 1)) hold.
       It holds that (proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1) ≤ a n) (v).
       We need to show that (proj1_sig(_, _, lim_sup_bdd a (i) (ii)) - 1 / (m + 1) < a k).
@@ -115,7 +115,7 @@ Lemma sequence_ub_bds :
   ∀ (a : ℕ → ℝ) (i : has_ub a) (N₀ : ℕ) (n : ℕ),
     (n ≥ N₀)%nat ⇒ a n ≤ sequence_ub a (i) N₀.
 Proof.
-    Take a : (ℕ → ℝ). 
+    Take a : (ℕ → ℝ).
     Assume that (has_ub a) (i).
     Take N₀, n : ℕ; such that (n ≥ N₀)%nat.
     We need to show that (a n ≤ lub (fun k ↦ (a (N₀ + k)%nat), maj_ss a N₀ (i))).
@@ -123,13 +123,13 @@ Proof.
       (a n ≤ (let (a0, _) := ub_to_lub (fun k ↦ (a (N₀ + k)%nat), maj_ss a N₀ (i)) in a0)).
     Define ii := (ub_to_lub (fun (k : ℕ) ↦ a (N₀ +k)%nat) (maj_ss a N₀ (i))).
     clear _defeq.
-    Obtain such an M. It holds that 
-      (is_lub (EUn (fun (k : ℕ) ↦ a (N₀ +k)%nat)) M).
-    It holds that (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), M)
-      ∧ (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ M ≤ b)) (iii).
-    Because (iii) both (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), M))
-      and (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ M ≤ b) hold.
-    It holds that (for all x : ℝ, EUn (fun k ↦ (a (N₀ + k)%nat), x) ⇨ x ≤ M).
+    Obtain such an l. It holds that
+      (is_lub (EUn (fun (k : ℕ) ↦ a (N₀ +k)%nat)) l).
+    It holds that (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), l)
+      ∧ (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ l ≤ b)) (iii).
+    Because (iii) both (Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), l))
+      and (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ l ≤ b) hold.
+    It holds that (for all x : ℝ, EUn (fun k ↦ (a (N₀ + k)%nat), x) ⇨ x ≤ l).
     It holds that (N₀ + (n-N₀) = n)%nat.
     It suffices to show that (EUn (fun (k : ℕ) ↦ (a (N₀ + k)%nat)) (a n)).
     We need to show that (there exists k : ℕ, a n = a (N₀ + k)%nat).
@@ -150,16 +150,16 @@ Proof.
     Define L_with_proof := (lim_sup_bdd a (i) (ii)).
     Define L := (proj1_sig L_with_proof).
     Define sequence_ub_cv_to_L := (proj2_sig L_with_proof).
-    We claim that (∃ m : ℕ → ℕ, is_index_seq m 
+    We claim that (∃ m : ℕ → ℕ, is_index_seq m
       ∧ ∀ k : ℕ, a (m k) > L - 1 / (INR(k) + 1)).
     {
-      By exists_subseq_to_limsup_bdd it holds that 
-        (there exists n : ℕ ⇨ ℕ, is_index_seq n 
-          ∧ (for all k : ℕ, a (n k) > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (k + 1))).
+      By exists_subseq_to_limsup_bdd it holds that
+        (there exists m_seq : ℕ ⇨ ℕ, is_index_seq m_seq
+          ∧ (for all k : ℕ, a (m_seq k) > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (k + 1))).
       Obtain such an m_seq. It holds that
        (is_index_seq m_seq ∧
         (for all k : ℕ, a (m_seq k) > proj1_sig(_,_,lim_sup_bdd a i ii) - 1 / (k + 1))) (v).
-      Because (v) both (is_index_seq m_seq) and 
+      Because (v) both (is_index_seq m_seq) and
         (for all k : ℕ, a (m_seq k) > proj1_sig(_,_,lim_sup_bdd a (i) (ii)) - 1 / (k + 1)) (vi) hold.
       Choose m := m_seq.
       We show both statements.
@@ -180,7 +180,7 @@ Proof.
       By (v) we conclude that (is_index_seq n).
     - We need to show that (Un_cv (fun k ↦ a(n(k)), L)).
       (** TODO: an equivalent to "apply with" would be nice here *)
-      apply (squeeze_theorem (fun (k : ℕ) ↦ L - 1 / (INR k + 1)) 
+      apply (squeeze_theorem (fun (k : ℕ) ↦ L - 1 / (INR k + 1))
         (fun (k : ℕ) ↦ (a (n k)))
         (sequence_ub a (i))).
       + (* apply squeeze_theorem with (c := sequence_ub a (i))
@@ -203,7 +203,7 @@ Qed.
 
 (** ## The Bolzano-Weierstrass Theorem*)
 Theorem Bolzano_Weierstrass :
-  ∀ (a : ℕ → ℝ), has_ub a ⇒ (has_lb a ⇒ 
+  ∀ (a : ℕ → ℝ), has_ub a ⇒ (has_lb a ⇒
     ∃ (n : ℕ → ℕ) (l : ℝ), is_index_seq n ∧
       Un_cv (fun (k : ℕ) ↦ a (n k)) l ).
 Proof.
@@ -212,10 +212,10 @@ Proof.
     Assume that (has_lb a) (ii).
     Define iii := (maj_min a (i) (ii)).
     By Bolzano_Weierstrass_gen it holds that
-      (∃ (n : ℕ → ℕ), is_index_seq n
-        ∧ Un_cv (fun (k : ℕ) ↦ a (n k)) (proj1_sig (_,_,lim_sup_bdd a (i) (iii)))) (iv).
+      (∃ (n0 : ℕ → ℕ), is_index_seq n0
+        ∧ Un_cv (fun (k : ℕ) ↦ a (n0 k)) (proj1_sig (_,_,lim_sup_bdd a (i) (iii)))) (iv).
     Obtain such an n0. It holds that
-      (is_index_seq n0 ∧ 
+      (is_index_seq n0 ∧
         Un_cv (fun (k : ℕ) ↦ a (n0 k)) (proj1_sig (_,_,lim_sup_bdd a (i) (iii)))) (v).
     Choose n := n0.
     Choose l := (proj1_sig (_,_,lim_sup_bdd a (i) (iii))).
@@ -231,9 +231,9 @@ Proof.
     Assume that (has_ub a) (i).
     Take x : ℝ.
     Assume that (is_seq_acc_pt a x).
-    It holds that (there exists n : ℕ → ℕ, is_index_seq n 
+    It holds that (there exists n : ℕ → ℕ, is_index_seq n
       ∧ Un_cv (fun k ↦ a(n(k)), x)).
-    Obtain such an n. It holds that 
+    Obtain such an n. It holds that
       (is_index_seq n ∧ Un_cv (fun k ↦ a(n(k)), x)) (iii).
     Because (iii) both (is_index_seq n) and (Un_cv (fun k ↦ a(n(k)), x)) hold.
     Take m : ℕ.
@@ -275,15 +275,15 @@ Proof.
       By acc_pt_bds_seq_ub it holds that (∀ m : ℕ, x ≤ sequence_ub a (i) m).
       Define iii := (lim_sup_bdd a (i) (ii)).
       clear _defeq.
-      Obtain such an L. simpl.
+      Obtain such an l. simpl.
       By (low_bd_seq_is_low_bd_lim (sequence_ub a (i)))
-          it holds that (L ≥ x).
-      We conclude that (x ≤ L).
-    - We need to show that (for all b : ℝ, Raxioms.is_upper_bound (is_seq_acc_pt a) b 
+          it holds that (l ≥ x).
+      We conclude that (x ≤ l).
+    - We need to show that (for all b : ℝ, Raxioms.is_upper_bound (is_seq_acc_pt a) b
         ⇨ proj1_sig (_,_,lim_sup_bdd a (i) (ii)) ≤ b).
       Take b : ℝ; such that (Raxioms.is_upper_bound (is_seq_acc_pt a) b).
       It holds that (for all x : ℝ, is_seq_acc_pt a x ⇨ x ≤ b).
-      It holds that (for all x : ℝ, 
+      It holds that (for all x : ℝ,
         (there exists n : ℕ ⇨ ℕ, is_index_seq n ∧ Un_cv (fun k ↦ a(n(k)), x)) ⇨ x ≤ b) (iii).
       By (iii) it suffices to show that (there exists n : ℕ ⇨ ℕ, is_index_seq n
         ∧ Un_cv (fun k ↦ a(n(k))) (proj1_sig (_,_,lim_sup_bdd a (i) (ii)))).
@@ -295,8 +295,8 @@ Qed.
 (** In a sequence, either there are finitely many terms larger than or equal to a given number $L$, or for every $N$ there is an $n \geq N$ such that $a_n \geq L$.*)
 Lemma finite_or_find_one :
   ∀ (a : ℕ → ℝ) (L : ℝ),
-    (∃ N : ℕ, ∀ k : ℕ, (k >= N)%nat ⇒ a k < L) 
-       ∨ 
+    (∃ N : ℕ, ∀ k : ℕ, (k >= N)%nat ⇒ a k < L)
+       ∨
     (∀ m : ℕ, ∃ n : ℕ, (n >= m)%nat ∧ a n ≥ L).
 Proof.
     Take a : (ℕ → ℝ).

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -41,7 +41,7 @@ A sequence of real numbers is a function from the natural numbers to the real nu
 
 (** *** Examples of sequences
 
-Let us give a few examples of sequences of real numbers. The first example is the sequence $a_seq : ℕ → ℝ$ defined by 
+Let us give a few examples of sequences of real numbers. The first example is the sequence $a_seq : ℕ → ℝ$ defined by
 
 $$a_seq := \mathsf{fun} \   n \mapsto \mathsf{INR}(n) + 2.$$
 
@@ -49,7 +49,7 @@ In Waterproof, we can write this as*)
 
 Definition a_seq : ℕ → ℝ := fun n ↦ INR(n) + 2.
 (** We could also have written that $a_seq: \mathbb{N} → ℝ$ is defined by $(a_seq)_n := \mathsf{INR} (n) + 2$, and usually we just leave out the function $\mathsf{INR}$ and would write $(a_seq)_n := n + 2$.*)
-(** 
+(**
 Another example is the sequence $y_seq: ℕ → ℝ$ defined by $(y_seq)_n := 3$. The sequence $y_seq$ is just constant! Within Waterproof, we could define the sequence $y_seq$ by
 ```
 Definition y_seq : ℕ → ℝ := 3.
@@ -60,7 +60,7 @@ However, let us also give an alternative way, which looks a  bit closer to the d
 Definition y_seq (n : ℕ) := 3.
 (** ** Terminology about sequences
 
-We call the function values $a(0)$, $a(1)$, $a(2)$, $\dots$ the **elements** of the sequence. Instead of $a(n)$, in mathematics we often write $a_n$. Moreover, instead of writing *let $a : \mathbb{N} \to \mathbb{R}$ be a sequence*, one often writes *let $(a_n)_{n \in \mathbb{N}}$ be a sequence*, or even shorter *let $(a_n)$ be a sequence*. 
+We call the function values $a(0)$, $a(1)$, $a(2)$, $\dots$ the **elements** of the sequence. Instead of $a(n)$, in mathematics we often write $a_n$. Moreover, instead of writing *let $a : \mathbb{N} \to \mathbb{R}$ be a sequence*, one often writes *let $(a_n)_{n \in \mathbb{N}}$ be a sequence*, or even shorter *let $(a_n)$ be a sequence*.
 
 The reason for the name *sequence* becomes clearer by writing the elements in a row, i.e. in a sequence,
 $$
@@ -127,9 +127,9 @@ Proof.
       for all n : ℕ, (n ≥ M)%nat ⇨ |b n - l| < ε ).
     Take ε : ℝ; such that (ε > 0).
     It holds that
-      (there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat ⇨ |a n - l| < ε).
+      (there exists N1 : ℕ, for all n : ℕ, (n ≥ N1)%nat ⇨ |a n - l| < ε).
     Obtain such an N1.
-    By (i) it holds that 
+    By (i) it holds that
       (there exists K : nat, for all n : ℕ, (n ≥ K)%nat ⇨ a n = b n).
     Obtain such a K.
     Choose M := (Nat.max N1 K).
@@ -188,18 +188,18 @@ Definition d := fun (n : ℕ) ↦ 1 / (n + 1).
 Lemma lim_d_0 : Un_cv d 0.
 Proof.
     We need to show that (Un_cv (fun n => 1 / (n + 1)) 0).
-    We need to show that (for all ε : ℝ, ε > 0 
-      ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat 
+    We need to show that (for all ε : ℝ, ε > 0
+      ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat
       ⇨ ｜ 1 / (n + 1) - 0 ｜ < ε ).
     Take ε : ℝ; such that (ε > 0).
-    By archimed_mod it holds that (there exists n : ℕ, n > / ε).
+    By archimed_mod it holds that (there exists n1 : ℕ, n1 > / ε).
     Obtain such an n1. Choose N := n1.
     Take n : ℕ; such that (n ≥ n1)%nat.
     It suffices to show that (-ε < 1 / (n + 1) - 0 < ε).
     We show both (-ε < 1 / (n + 1) - 0) and (1 / (n + 1) - 0 < ε).
     - It holds that (0 < n + 1). (* n + 1 > 0 is difficult?*)
       We conclude that (& -ε < 0 < / (n + 1) = 1 / (n + 1) - 0).
-    - We claim that (/ ε < n + 1). 
+    - We claim that (/ ε < n + 1).
       { We conclude that (& / ε < n1 <= n <= n + 1). }
       We conclude that (& 1 / (n + 1) - 0 = / (n + 1) < / / ε = ε).
 Qed.
@@ -229,9 +229,9 @@ Proof.
     Assume that (c ⟶ l).
     To show: (∀ ε : ℝ, ε > 0 ⇒ ∃ Nn : ℕ, ∀ n : ℕ, (n ≥ Nn)%nat ⇒ |b n - l| < ε).
     Take ε : ℝ; such that (ε > 0).
-    It holds that (∃ N : ℕ, ∀ n : ℕ, (n ≥ N)%nat ⇒ |a n - l| < ε).
+    It holds that (∃ Na : ℕ, ∀ n : ℕ, (n ≥ Na)%nat ⇒ |a n - l| < ε).
     Obtain such an Na.
-    It holds that (∃ N : ℕ, ∀ n : ℕ, (n ≥ N)%nat ⇒ |c n - l| < ε).
+    It holds that (∃ Nc : ℕ, ∀ n : ℕ, (n ≥ Nc)%nat ⇒ |c n - l| < ε).
     Obtain such an Nc.
     Choose Nn := (Nat.max Na Nc).
     Take n : ℕ; such that (n ≥ Nn)%nat.
@@ -257,7 +257,7 @@ Qed.
 
 Lemma upp_bd_seq_is_upp_bd_lim :
   ∀ (a : ℕ → ℝ) (L M: ℝ),
-    (∀ n : ℕ, a n ≤ M) ⇒ 
+    (∀ n : ℕ, a n ≤ M) ⇒
       (Un_cv a L) ⇒ L ≤ M.
 Proof.
     Take a : (ℕ → ℝ).
@@ -272,10 +272,10 @@ Proof.
     - Case (M < L).
       Define ε := (L-M).
       It holds that (ε > 0).
-      It holds that (for all eps : ℝ, eps > 0 
-        ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat 
+      It holds that (for all eps : ℝ, eps > 0
+        ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat
         ⇨ ｜ a n - L ｜ < eps).
-      It holds that (∃ N : ℕ, ∀n : ℕ, (n ≥ N)%nat ⇒ R_dist (a n) L < ε).
+      It holds that (∃ Nn : ℕ, ∀n : ℕ, (n ≥ Nn)%nat ⇒ R_dist (a n) L < ε).
       Obtain such an Nn.
       It holds that (|a(Nn) - L| < ε).
       By Rabs_def2 it holds that (a Nn - L < ε ∧ (- ε < a Nn - L)).
@@ -288,7 +288,7 @@ Qed.
 
 Lemma low_bd_seq_is_low_bd_lim :
   ∀ (a : ℕ → ℝ) (L M: ℝ),
-    (∀ n : ℕ, a n ≥ M) ⇒ 
+    (∀ n : ℕ, a n ≥ M) ⇒
       (Un_cv a L) ⇒ L ≥ M.
 Proof.
     Take a : (ℕ → ℝ).
@@ -326,10 +326,10 @@ Proof.
     It holds that (l < m).
     Define ε := ((m - l)/2).
     It holds that (ε > 0).
-    It holds that (for all eps : ℝ, eps > 0 
-      ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat 
+    It holds that (for all eps : ℝ, eps > 0
+      ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat
       ⇨ ｜ a n - m ｜ < eps).
-    It holds that (for all eps : ℝ, eps > 0 
+    It holds that (for all eps : ℝ, eps > 0
       ⇨ there exists N : ℕ, for all n : ℕ, (n ≥ N)%nat
       ⇨ ｜ b n - l ｜ < eps).
     It holds that (∃ N1 : ℕ, ∀ n : ℕ, (n ≥ N1)%nat ⇒ R_dist (a n) m < ε).
@@ -342,48 +342,48 @@ Proof.
       It holds that (|a(N3) - m| < ε).
       By Rabs_def2 it holds that (a N3 - m < ε ∧ - ε < a N3 - m).
       By Rabs_def2 it holds that (b N3 - l < ε ∧ - ε < b N3 - l).
-      We conclude that (& b N3 < l + ε = l + (m - l)/2 
+      We conclude that (& b N3 < l + ε = l + (m - l)/2
                             = m - (m - l)/2 = m - ε < a N3).
     }
     It holds that (a N3 <= b N3).
     Contradiction.
 Qed.
 
-Definition is_bounded (a : ℕ → ℝ) := 
+Definition is_bounded (a : ℕ → ℝ) :=
   ∃ q : ℝ,
     ∃ M : ℝ, M > 0 ∧
-      ∀ n : ℕ, 
+      ∀ n : ℕ,
         |a n - q| ≤ M.
 Notation "a 'is' '_bounded_'" := (is_bounded a) (at level 20).
 Notation "a 'is' 'bounded'" := (is_bounded a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded (statement : constr) := eval unfold is_bounded in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded (Some "bounded") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded (Some "bounded") false.
 
 Definition is_bounded_equivalent (a : ℕ → ℝ) :=
-  ∃ M : ℝ, M > 0 ∧ 
+  ∃ M : ℝ, M > 0 ∧
     ∀ n : ℕ, |a n| ≤ M.
-    
-Lemma is_bounded_equivalence : 
+
+Lemma is_bounded_equivalence :
   ∀ (a : ℕ → ℝ),
-    is_bounded a ⇔ 
+    is_bounded a ⇔
       is_bounded_equivalent a.
 Proof.
 Take a : (ℕ → ℝ).
 We show both directions.
 - We need to show that (is_bounded a ⇨ is_bounded_equivalent a).
   Assume that (is_bounded a).
-  It holds that (there exists q : R, 
+  It holds that (there exists q : R,
     there exists M1 : R, M1 > 0 ∧ (for all n : ℕ, | a n - q | ≤ M1)).
   Obtain such a q.
   It holds that (there exists M1 : R, M1 > 0 ∧ (for all n : ℕ, | a n - q | ≤ M1)).
   Obtain such an M1.
   It holds that (M1 > 0 ∧ (for all n : ℕ, | a n - q | ≤ M1)) (i).
-  Because (i) both (M1 > 0) and 
+  Because (i) both (M1 > 0) and
     (for all n : ℕ, | a n - q | ≤ M1).
   We need to show that (
     there exists M : ℝ ,
@@ -401,13 +401,13 @@ We show both directions.
         | a n | ≤ M ).
     Take n : ℕ.
     By Rabs_triang it holds that (|a n - q + q| ≤ |a n - q| + |q|).
-    We conclude that (& |a n| = |a n - q + q| 
+    We conclude that (& |a n| = |a n - q + q|
                               <= (|a n - q| + |q|) <= (M1 + |q|) = M).
 
 - We need to show that (
     is_bounded_equivalent a ⇨ is_bounded a).
   Assume that (there exists M1 : ℝ, M1 > 0 ∧ ∀ n : ℕ, |a n| ≤ M1).
-  Obtain such an M1. It holds that 
+  Obtain such an M1. It holds that
     (M1 > 0 ∧ ∀ n : ℕ, |a n| ≤ M1) (i).
   Because (i) both (M1 > 0) and
   (for all n : ℕ, | a n | ≤ M1) hold.
@@ -430,15 +430,15 @@ for all n : ℕ,
 Qed.
 
 (** Definitions sequence bounded from above and below *)
-Definition is_bounded_above (a : ℕ → ℝ) := 
+Definition is_bounded_above (a : ℕ → ℝ) :=
   ∃ M : ℝ, ∀ n : ℕ, a(n) ≤ M.
 Notation "a 'is' '_bounded' 'above_'" := (is_bounded_above a) (at level 20).
 Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_above (statement : constr) := eval unfold is_bounded_above in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded_above (Some "bounded above") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded_above (Some "bounded above") false.
 
@@ -447,15 +447,15 @@ Definition is_bounded_below (a : ℕ → ℝ) :=
 Notation "a 'is' '_bounded' 'below_'" := (is_bounded_below a) (at level 20).
 Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_below (statement : constr) := eval unfold is_bounded_below in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded_below (Some "bounded below") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_is_bounded_below (Some "bounded below") false.
 
 (** Convergence to +∞ and -∞. *)
-Definition diverges_to_plus_infinity (a : ℕ → ℝ) := 
+Definition diverges_to_plus_infinity (a : ℕ → ℝ) :=
   ∀ M : ℝ,
     ∃ N1 : ℕ,
       ∀ n : ℕ, (n ≥ N1)%nat ⇒
@@ -464,23 +464,23 @@ Definition diverges_to_plus_infinity (a : ℕ → ℝ) :=
 Notation "a ⟶ ∞" := (diverges_to_plus_infinity a) (at level 20).
 Notation "a '_diverges' 'to' '∞_'" := (diverges_to_plus_infinity a) (at level 20).
 Notation "a 'diverges' 'to' '∞'"   := (diverges_to_plus_infinity a) (at level 20, only parsing).
-Local Ltac2 unfold_diverge_plus_infty (statement : constr) := 
+Local Ltac2 unfold_diverge_plus_infty (statement : constr) :=
   eval unfold diverges_to_plus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") false.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") false.
-  
 
-Definition diverges_to_minus_infinity (a : ℕ → ℝ) := 
+
+Definition diverges_to_minus_infinity (a : ℕ → ℝ) :=
   ∀ M : ℝ,
     ∃ N1 : ℕ,
       ∀ n : ℕ, (n ≥ N1)%nat ⇒
@@ -489,18 +489,18 @@ Definition diverges_to_minus_infinity (a : ℕ → ℝ) :=
 Notation "a ⟶ -∞" := (diverges_to_minus_infinity a) (at level 20).
 Notation "a '_diverges' 'to' '-∞_'" := (diverges_to_minus_infinity a) (at level 20).
 Notation "a 'diverges' 'to' '-∞'"   := (diverges_to_minus_infinity a) (at level 20, only parsing).
-Local Ltac2 unfold_diverge_minus_infty (statement : constr) := 
+Local Ltac2 unfold_diverge_minus_infty (statement : constr) :=
   eval unfold diverges_to_minus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞":= 
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞":=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") false.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" := 
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", "()"))) := 
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", "()"))) :=
   panic_if_goal_wrapped ();
   unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") false.
 

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -28,7 +28,7 @@ Waterproof Enable Automation RealsAndIntegers.
 
 Open Scope R_scope.
 Open Scope metric_scope.
-Definition is_index_sequence (n : ℕ → ℕ) := 
+Definition is_index_sequence (n : ℕ → ℕ) :=
   ∀ k : ℕ, (n k < n (k + 1))%nat.
 
 Notation "n 'is' 'an' '_index' 'sequence_'" := (is_index_sequence n) (at level 68) : metric_scope.
@@ -56,7 +56,7 @@ Section my_section.
 Variable X : Metric_Space.
 
 
-Definition is_subsequence (b : ℕ → X) (a : ℕ → X) := 
+Definition is_subsequence (b : ℕ → X) (a : ℕ → X) :=
     ∃ m : (ℕ → ℕ),
         is_index_sequence m ∧ ∀ k : ℕ,
             b k = (a ◦ m) k.
@@ -67,40 +67,40 @@ Definition is_accumulation_point (p : X) (a : ℕ → X) :=
 
 
 Lemma index_sequence_property (n : ℕ → ℕ) :
-    is_index_sequence n ⇒ 
+    is_index_sequence n ⇒
         ∀ k : ℕ,
             (n k ≥ k)%nat.
 Proof.
-  intros. 
+  intros.
   unfold is_index_sequence in H.
   induction k.
-  specialize (H 0%nat). 
+  specialize (H 0%nat).
   unfold ge.
   apply Nat.le_0_l.
-  specialize (H k). 
-  unfold ge. 
-  apply Nat.le_succ_l. 
+  specialize (H k).
+  unfold ge.
+  apply Nat.le_succ_l.
   rewrite Nat.add_1_r in H.
-  apply (Nat.le_lt_trans k (n k)). 
-  apply IHk. 
+  apply (Nat.le_lt_trans k (n k)).
+  apply IHk.
   apply H.
 Qed.
 
 
 
 Lemma index_seq_equiv (n : ℕ → ℕ) : is_index_seq n ⇔ is_index_sequence n.
-Proof. 
+Proof.
   We show both directions.
   - We need to show that (is_index_seq n ⇨ is_index_sequence n).
     intro.
-    unfold is_index_sequence. 
-    Take k : ℕ. 
+    unfold is_index_sequence.
+    Take k : ℕ.
     unfold is_index_seq in H.
     We conclude that ((n k < n (k + 1))%nat).
   - We need to show that (is_index_sequence n ⇨ is_index_seq n).
     intro.
-    unfold is_index_seq. 
-    Take k : ℕ. 
+    unfold is_index_seq.
+    Take k : ℕ.
     unfold is_index_sequence in H.
     We conclude that ((n k < n (k + 1))%nat).
 Qed.
@@ -115,7 +115,7 @@ Lemma incr_loc_to_glob :
     is_increasing g
       ⇒ (∀ k l : ℕ, (k ≤ l)%nat ⇒ (g k ≤ g l)%nat).
 Proof.
-    (* There exists already a constant called [f].*) 
+    (* There exists already a constant called [f].*)
     Take g : (ℕ → ℕ).
     We need to show that
       ((for all k : ℕ, (g k ≤ g (k + 1))%nat) ⇨ for all k l : ℕ, (k ≤ l ⇨ g k ≤ g l)%nat ).
@@ -138,15 +138,15 @@ Proof.
         It suffices to show that (g k = g (l + 1))%nat.
         We conclude that (g k = g (l + 1))%nat.
       + (** Finally we consider the case $k > S(l)$. However, this case is in contradiction with $k \leq S(l)$. *)
-        It holds that (¬(l + 1 < k)%nat). 
+        It holds that (¬(l + 1 < k)%nat).
         Contradiction.
 Qed.
 
 
-Lemma index_sequence_property2 (n : ℕ → ℕ) : 
-    is_index_sequence n ⇒ 
-        ∀ k1 k2 : ℕ, 
-            (k1 ≥ k2)%nat ⇒ 
+Lemma index_sequence_property2 (n : ℕ → ℕ) :
+    is_index_sequence n ⇒
+        ∀ k1 k2 : ℕ,
+            (k1 ≥ k2)%nat ⇒
                 (n k1 ≥ n k2)%nat.
 Proof.
     Assume that (is_index_sequence n).
@@ -178,20 +178,20 @@ Take a : (ℕ → X). Take p : X.
 Assume that (a ⟶ p).
 Take n : (ℕ → ℕ).
 Assume that (is_index_sequence n).
-It suffices to show that (∀ ε : ℝ, ε > 0 ⇒ ∃ N3 : ℕ, ∀ k : ℕ, (k ≥ N3)%nat ⇒ dist _ (a (n k)) p < ε).
+It suffices to show that (∀ ε : ℝ, ε > 0 ⇒ ∃ N0 : ℕ, ∀ k : ℕ, (k ≥ N0)%nat ⇒ dist _ (a (n k)) p < ε).
 
 Take ε : ℝ; such that (ε > 0).
-It holds that (∃ N3 : ℕ, ∀ k : ℕ, (k ≥ N3)%nat → dist _ (a k) p < ε).
-Obtain such a K. Choose N3 := K.
-Take k : ℕ; such that (k ≥ N3)%nat.
-By index_sequence_property2 it holds that (n k ≥ n K)%nat.
-By index_sequence_property it holds that (n K ≥ K)%nat.
-assert (H3 : (n k ≥ K)%nat) by auto with zarith.
+It holds that (∃ N1 : ℕ, ∀ k : ℕ, (k ≥ N1)%nat → dist _ (a k) p < ε).
+Obtain such an N1. Choose N0 := N1.
+Take k : ℕ; such that (k ≥ N1)%nat.
+By index_sequence_property2 it holds that (n k ≥ n N1)%nat.
+By index_sequence_property it holds that (n N1 ≥ N1)%nat.
+assert (H3 : (n k ≥ N1)%nat) by auto with zarith.
 We conclude that (dist _ (a (n k)) p < ε).
 Qed.
 
-Lemma equivalent_subsequence_convergence : 
-  ∀ (x y : ℕ → X), is_subsequence y x ⇒ 
+Lemma equivalent_subsequence_convergence :
+  ∀ (x y : ℕ → X), is_subsequence y x ⇒
     ∀ p : X, x ⟶ p ⇒
       y ⟶ p.
 Proof.
@@ -202,15 +202,15 @@ Assume that (x ⟶ p).
 
 We need to show that (y ⟶ p).
 It holds that (∃ m : ℕ → ℕ, is_index_sequence m ∧ ∀ k : ℕ, y k = (x ◦ m) k).
-Obtain such an m. It holds that 
+Obtain such an m. It holds that
   (is_index_sequence m ∧ ∀ k : ℕ, y k = (x ◦ m) k) (i).
-Because (i) both (is_index_sequence m) and 
+Because (i) both (is_index_sequence m) and
   (for all k : nat, y k = x (m k)) hold.
 
 It suffices to show that (∀ ε : ℝ, ε > 0 ⇒ ∃ N3 : ℕ, ∀ k : ℕ, (k ≥ N3)%nat ⇒ dist _ (y k) p < ε).
 
 Take ε : ℝ; such that (ε > 0).
-It holds that (∃ N3 : ℕ, ∀ k : ℕ, (k ≥ N3)%nat → dist _ (x k) p < ε).
+It holds that (∃ K : ℕ, ∀ k : ℕ, (k ≥ K)%nat → dist _ (x k) p < ε).
 Obtain such a K. Choose N3 := K.
 Take k : ℕ; such that (k ≥ N3)%nat.
 By index_sequence_property2 it holds that (m k ≥ m K)%nat.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -62,7 +62,7 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
       match Constr.has_evar t with
       | true =>
         rename_blank_evars_in_term (Ident.to_string s) t;
-        warn (concat_list [of_string "Please come back to this line to make a definitive choice for "; of_ident s; of_string "."; fnl ();
+        warn (concat_list [of_string "Please come back later to make a definitive choice for "; of_ident s; of_string "."; fnl ();
         of_string "For now you can use that "; of_constr constr:($v = $t); of_string "."])
       | _ => ()
       end;
@@ -102,7 +102,7 @@ Ltac2 choose_variable_in_exists_no_renaming (t:constr) :=
       match Constr.has_evar t with
       |  true =>
         rename_blank_evars_in_term name t;
-        warn (concat_list [of_string "Please come back to this line later to make a definite choice."]);
+        warn (concat_list [of_string "Please come back later to make a definite choice."]);
         eexists $t
       |  false => exists $t
       end

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -19,6 +19,7 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
+Require Import Util.Binders.
 Require Import Util.Goals.
 Require Import Util.MessagesToUser.
 Require Import Util.Evars.
@@ -37,7 +38,7 @@ Local Ltac2 _binder_name_equal (name : ident) (b : binder) :=
 (** * Choose *)
 
 (**
-    
+
   Instantiate a variable in an [exists] [goal], according to a given [constr], and also renames the [constr]. The [constr] can contain blanks, which are filled in
   with freshly named evars, so that the user can refer to them later.
 
@@ -54,41 +55,20 @@ Local Ltac2 _binder_name_equal (name : ident) (b : binder) :=
 Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
   lazy_match! goal with
     | [ |- ex ?a] =>
-      (* Check for correct binder name *)
-      match Constr.Unsafe.kind a with
-      | Constr.Unsafe.Lambda b _ =>
-          match Constr.Binder.name b with
-          | None => () (* TODO: is it true that we want to do nothing here?,
-                          i.e. in the case of anonymous binders. *)
-          | Some binder_name =>
-            (* If a variable already exists, the binder gets renamed visually, but 
-            the binder name internally remains the same.
-            This gives confusing behavior. To go around this,
-            we try to guess what the binder got renamed into by introducing a fresh
-            ident based on the binder name. *)
-            let fresh_binder_name := Fresh.fresh (Fresh.Free.of_goal () ) binder_name in 
-            if Bool.neg (Ident.equal fresh_binder_name s) then
-              warn (concat_list [of_string "A variable name "; of_ident fresh_binder_name;
-                of_string " was expected, but a variable name "; of_ident s;
-                of_string " was given.
-The variable has been renamed."])
-            else ()
-          end
-      | _ => ()
-      end;
+      check_binder_name a s;
       set ($s := $t);
       let v := Control.hyp s in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
       match Constr.has_evar t with
-      | true => 
+      | true =>
         rename_blank_evars_in_term (Ident.to_string s) t;
         warn (concat_list [of_string "Please come back to this line to make a definitive choice for "; of_ident s; of_string "."; fnl ();
-        of_string "For now you can use that "; of_constr constr:($v = $t)])
+        of_string "For now you can use that "; of_constr constr:($v = $t); of_string "."])
       | _ => ()
       end;
-      exists $v;      
+      exists $v;
       assert ($w : $v = $t) by reflexivity
-      
+
     | [ |- _ ] => throw (of_string "`Choose` can only be applied to 'exists' goals.")
   end.
 
@@ -131,7 +111,7 @@ Ltac2 choose_variable_in_exists_no_renaming (t:constr) :=
 
 Ltac2 Notation "Choose" s(opt(seq(ident, ":="))) t(open_constr) :=
   panic_if_goal_wrapped ();
-  match s with 
+  match s with
     | None => choose_variable_in_exists_no_renaming t
     | Some s => choose_variable_in_exists_goal_with_renaming s t
   end.

--- a/theories/Tactics/Obtain.v
+++ b/theories/Tactics/Obtain.v
@@ -30,76 +30,39 @@ Require Import Util.MessagesToUser.
 (** Tries to make the assertion [True] with label [label].
   Throws an error if this fails, i.e. if the label is already used
   for another one of the hypotheses.
-  
-  This check was separated out from the 'assert'-tactics below because the 
+
+  This check was separated out from the 'assert'-tactics below because the
   '[label] is already used error' would otherwise be caught in
   the code meant to catch [AutomationFailure] errors. *)
 
 Local Ltac2 try_out_label (label : ident) :=
-  match Control.case (fun () => 
+  match Control.case (fun () =>
     assert True as $label by exact I)
   with
   | Err exn => Control.zero exn
   | Val _ => clear $label
   end.
 
-(** Destructs the statement with label [og_label] into the variable named [var_label] 
-  and the corresponding property. Copies statement [og_label] such that the statement 
-  is preserved despite its destruction. 
-  
-  The original, not the copy, is destructed because with sigma types the goal
-  or other hypotheses can depend on the specific instance of the original.*)  
+(** Destructs the statement with label [og_label] into the variable named [var_label]
+  and the corresponding property. Copies statement [og_label] such that the statement
+  is preserved despite its destruction.
 
+  The original, not the copy, is destructed because with sigma types the goal
+  or other hypotheses can depend on the specific instance of the original.
+
+  Returns:
+    - the name of the new hypothesis. *)
 Local Ltac2 copy_and_destruct (og_label : ident) (var_label : ident) :=
+  let prop_label := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
   let og_term := Control.hyp og_label in
   let og_type := get_type og_term in
-  (* make temporary copy; destruct original; make new copy with original label. *)
-  (* make temporary copy statement *)     
-  let temp_id := Fresh.in_goal @_temp_copy in
-  assert $og_type as $temp_id;
-  Control.focus 1 1 (fun () => exact $og_term); 
-    (* (above line) separate from 'assert' 
-      as otherwise $copy_id could not be found..?*)
-  (* destruct original *)
-  let prop_label := Fresh.in_goal @_H in
-  destruct $og_term as [$var_label $prop_label];
-  (* make new copy with original label *)
-  let temp_copy := Control.hyp temp_id in 
-  assert $og_type as $og_label;
-  Control.focus 1 1 (fun () => exact $temp_copy);
-  (* remove temporary copy *)
-  clear $temp_id.
+  assert $og_type as $prop_label;
+  Control.focus 1 1 (fun () => exact $og_term);
+  destruct $og_term as [$var_label $og_label];
+  Std.rename [(og_label, prop_label); (prop_label, og_label)];
+  prop_label.
 
 
-(** *
-  Attempts to obtain a variable from the previous statement.
-
-  Arguments:
-    - [var : ident], the name of the variable to be obtained.
-  Does:
-    - Destructs the previous statement into the variable [var] and its corresponding property.
-    - Copies the previous statement into a new statement with the same identifier 
-      to preserve the statement despite its destruction.
-
-  Raises fatal exceptions:
-    - If no statement to destruct or if the previous statement was not an
-      existence statement or a sigma type.
-*)
-
-Ltac2 obtain_according_to_last (var : ident) :=
-  lazy_match! goal with
-  | [id_h : _ |- _ ] => 
-    let h := Control.hyp id_h in
-    let type_h := get_type h in
-    lazy_match! type_h with
-    | ex  ?pred => copy_and_destruct id_h var
-    | sig ?pred => copy_and_destruct id_h var
-    | _ => throw (of_string 
-      "Previous statement is not of the form 'there exists ...'.")
-    end
-  | [ |- _] => throw (of_string 
-    "No statement to obtain variable from.")
-  end.
 
 (** *
   Attempts to obtain a variable from a user-specified statement.
@@ -112,24 +75,27 @@ Ltac2 obtain_according_to_last (var : ident) :=
     - Copies the statement [hyp] into a new statement with the same label [hyp]
       to preserve the statement despite its destruction.
 
+  Returns:
+    - the name of the new hypothesis.
+
   Raises exceptions:
     - [ObtainError], if no statement to destruct or if the previous statement was not an
       existence statement or a sigma type.
 *)
-
 Ltac2 obtain_according_to (var : ident) (hyp : ident) :=
   let h := Control.hyp hyp in
   let type_h := get_type h in
   lazy_match! type_h with
   | ex  ?pred => copy_and_destruct hyp var
   | sig ?pred => copy_and_destruct hyp var
-  | _ => throw (concat_list 
-    [of_string "Statement "; of_constr h; of_string " is not of the form 'there exists ...'."])
+  | _ => throw (concat_list
+    [of_string "Statement "; of_constr h; of_string " is not of the form 'there exists ...'."]);
+    @__doesnt_reach_here__
   end.
 
 (* Quick fix for Wateproof editor / Coq lsp, where
-  [Obtain such an 
-  
+  [Obtain such an
+
    Qed.]
   was interpreted [Obtain such an Qed.].
   Although in Coq [Qed] is acceptable as variable name, it is confusing.
@@ -141,14 +107,69 @@ Local Ltac2 panic_ident_Qed (i : ident) :=
   if Ident.equal i @Qed
     then throw (of_string "Syntax error: variable name expected after 'such'.")
     else ().
-  
-Ltac2 Notation "Obtain" "such" a(opt("a")) an(opt("an")) var(ident) :=
-  panic_ident_Qed (var);
-  panic_if_goal_wrapped ();
-  try_out_label var;
-  obtain_according_to_last var.
 
-Ltac2 Notation "Obtain" var(ident) "according" "to" hyp(seq("(", ident, ")")):=
+(** *
+  Attempts to obtain variables from the indicated statement.
+
+  Arguments:
+    - [vars : ident list], the names of the variable to be obtained.
+    - [hyp : ident], the label of the statement the variables should be obtained from.
+  Does:
+    - Destructs the statement [hyp] into the variables [vars] and their corresponding property.
+    - Copies the previous statement into a new statement with the same identifier
+      to preserve the statement despite its destruction.
+
+  Raises fatal exceptions:
+    - If no statement to destruct for the given
+      amount of variables or if the previous statement was not an
+      existence statement or a sigma type.
+*)
+Ltac2 obtain_seq_according_to (vars : ident list) (hyp) :=
+  let start_label := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
+  let _ := List.fold_left (
+    fun old_label var => panic_ident_Qed (var);
+    try_out_label var;
+    obtain_according_to var old_label)
+    vars hyp in
+  ().
+
+(** *
+  Attempts to obtain variables from the previous statement.
+
+  Arguments:
+    - [vars : ident list], the names of the variable to be obtained.
+  Does:
+    - Destructs the previous statement into the variables [vars] and their corresponding property.
+    - Copies the previous statement into a new statement with the same identifier
+      to preserve the statement despite its destruction.
+
+  Raises fatal exceptions:
+    - If no statement to destruct or if the previous statement was not an
+      existence statement or a sigma type.
+*)
+
+Ltac2 obtain_according_to_last (vars : ident list) :=
+  lazy_match! goal with
+  | [id_h : _ |- _ ] =>
+    let h := Control.hyp id_h in
+    let type_h := get_type h in
+    lazy_match! type_h with
+    | ex  ?pred =>
+      obtain_seq_according_to vars id_h
+    | sig ?pred => obtain_seq_according_to vars id_h
+    | _ => throw (of_string
+      "Previous statement is not of the form 'there exists ...'.")
+    end
+  | [ |- _] => throw (of_string
+    "No statement to obtain variable from.")
+  end.
+
+Ltac2 Notation "Obtain" "such" a(opt("a")) an(opt("an"))
+    vars(list1(ident, ",")) :=
   panic_if_goal_wrapped ();
-  try_out_label var;
-  obtain_according_to var hyp.
+  obtain_according_to_last vars.
+
+Ltac2 Notation "Obtain" vars(list1(ident, ",")) "according" "to"
+    hyp(seq("(", ident, ")")):=
+  panic_if_goal_wrapped ();
+  obtain_seq_according_to vars hyp.

--- a/theories/Tactics/Obtain.v
+++ b/theories/Tactics/Obtain.v
@@ -24,6 +24,7 @@ Local Ltac2 concat_list (ls : message list) : message :=
 Require Import Util.Init.
 Local Ltac2 get_type (x: constr) : constr := eval unfold type_of in (type_of $x).
 
+Require Import Util.Binders.
 Require Import Util.Goals.
 Require Import Util.MessagesToUser.
 
@@ -43,29 +44,7 @@ Local Ltac2 try_out_label (label : ident) :=
   | Val _ => clear $label
   end.
 
-Local Ltac2 check_binder_name (expr : constr)
-    (candidate_name : ident) :=
-  match Constr.Unsafe.kind expr with
-  | Constr.Unsafe.Lambda b _ =>
-    match Constr.Binder.name b with
-    | None => () (* TODO: is it true that we want to do nothing here?,
-                    i.e. in the case of anonymous binders. *)
-    | Some binder_name =>
-      (* If a variable already exists, the binder gets renamed visually, but
-      the binder name internally remains the same.
-      This gives confusing behavior. To go around this,
-      we try to guess what the binder got renamed into by introducing a fresh
-      ident based on the binder name. *)
-      let fresh_binder_name := Fresh.fresh (Fresh.Free.of_goal () ) binder_name in
-      if Bool.neg (Ident.equal fresh_binder_name candidate_name) then
-        warn (concat_list [of_string "A variable name "; of_ident fresh_binder_name;
-          of_string " was expected, but a variable name "; of_ident candidate_name;
-          of_string " was given.
-The variable has been renamed."])
-      else ()
-    end
-  | _ => ()
-  end.
+
 
 (** Destructs the statement with label [og_label] into the variable named [var_label]
   and the corresponding property. Copies statement [og_label] such that the statement

--- a/theories/Util/Assertions.v
+++ b/theories/Util/Assertions.v
@@ -190,7 +190,7 @@ Ltac2 assert_feedback_string_equals (expected_string : string) (msg : message) :
     print_success (of_string ("The feedback message is as expected"))
   else
     fail_test (concat_list [of_string "The feedback message is not as expected. Expected:"; fnl (); of_string expected_string; fnl ();
-    of_string "Got:"; fnl (); msg]).
+    of_string "Got:"; fnl (); of_string (Message.to_string msg)]).
 
 (**
   Asserts that the feedback messages produced by the tactic at a

--- a/theories/Util/Binders.v
+++ b/theories/Util/Binders.v
@@ -1,0 +1,60 @@
+(******************************************************************************)
+(*                  This file is part of Waterproof-lib.                      *)
+(*                                                                            *)
+(*   Waterproof-lib is free software: you can redistribute it and/or modify   *)
+(*    it under the terms of the GNU General Public License as published by    *)
+(*     the Free Software Foundation, either version 3 of the License, or      *)
+(*                    (at your option) any later version.                     *)
+(*                                                                            *)
+(*     Waterproof-lib is distributed in the hope that it will be useful,      *)
+(*      but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the         *)
+(*               GNU General Public License for more details.                 *)
+(*                                                                            *)
+(*     You should have received a copy of the GNU General Public License      *)
+(*   along with Waterproof-lib. If not, see <https://www.gnu.org/licenses/>.  *)
+(*                                                                            *)
+(******************************************************************************)
+
+From Ltac2 Require Import Ltac2.
+From Ltac2 Require Import Message.
+Require Import Util.MessagesToUser.
+
+Local Ltac2 concat_list (ls : message list) : message :=
+  List.fold_right concat (of_string "") ls.
+
+Local Ltac2 check_binder (b : binder) (candidate_name : ident) :=
+  match Constr.Binder.name b with
+| None => () (* TODO: is it true that we want to do nothing here?,
+                i.e. in the case of anonymous binders. *)
+| Some binder_name =>
+    (* If a variable already exists, the binder gets renamed visually, but
+    the binder name internally remains the same.
+    This gives confusing behavior. To go around this,
+    we try to guess what the binder got renamed into by introducing a fresh
+    ident based on the binder name. *)
+    let fresh_binder_name := Fresh.fresh (Fresh.Free.of_goal () ) binder_name in
+    if Bool.neg (Ident.equal fresh_binder_name candidate_name) then
+    warn (concat_list [of_string "Expected variable name "; of_ident fresh_binder_name;
+        of_string " instead of "; of_ident candidate_name;
+        of_string "."])
+    else ()
+ end.
+
+(**
+  Check whether the provided variable name [candidate_name]
+  corresponds to the first expected binder name in [expr].
+
+  Warns in case of a mismatch.
+
+  Arguments:
+  - [expr: constr], the expression in which a binder occurs of which the
+    name should be checked.
+  - [candidate_name : ident], the candidate name for the binder
+*)
+Ltac2 check_binder_name (expr : constr) (candidate_name : ident) :=
+  match (Constr.Unsafe.kind expr) with
+  | Constr.Unsafe.Lambda b _ => check_binder b candidate_name
+  | Constr.Unsafe.Prod b _=> check_binder b candidate_name
+  | _ => ()
+  end.


### PR DESCRIPTION
At first I thought this wouldn't be necessary, until I needed to obtain five variables for a lemma...

Allows for:

```
Goal (exists n m k l : nat, n + k + 1 = l + m)%nat -> True.
Proof.
  intro H.
  Obtain such an n, m, k, l.
Abort.
```

The tactic now also warns on unexpected variable names.