### PR TITLE
Fix that goals can be closed after choosing blanks or using magic

### DIFF
--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -178,12 +178,14 @@ Proof.
 Abort.
 
 (** Test 17: Cannot close the goal after choosing a blank,
-  even if automation has already resolved the evar. *)
-Goal ∃ n < 1%nat, (n ≥ 0)%nat.
+  regardless of whether automation has already resolved the evar. *)
+Goal ∃ n < 1%nat, True.
 Proof.
 Choose n := _.
-* Indeed, (n < 1)%nat.
-* We conclude that (n ≥ 0)%nat.
+{ We need to verify that ((n < 1)%nat).
+  We conclude that (n < 1)%nat.
+}
+* We conclude that (True).
 Fail (). (* no such goal *)
 Fail Qed. (* there are goals given up *)
 Abort.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -176,3 +176,14 @@ Proof.
     Indeed, (n ≤ S n)%nat.
   * We need to show that (INR(n) = 3).
 Abort.
+
+(** Test 17: Cannot close the goal after choosing a blank,
+  even if automation has already resolved the evar. *)
+Goal ∃ n < 1%nat, (n ≥ 0)%nat.
+Proof.
+Choose n := _.
+* Indeed, (n < 1)%nat.
+* We conclude that (n ≥ 0)%nat.
+Fail (). (* no such goal *)
+Fail Qed. (* there are goals given up *)
+Abort.

--- a/tests/tactics/Postpone.v
+++ b/tests/tactics/Postpone.v
@@ -59,3 +59,8 @@ Proof.
   assert_feedback_with_string (fun () => By magic we conclude that (0 = 1)) Warning
 "Please come back later to provide an actual proof of (0 = 1).".
 Abort.
+
+Goal False.
+  assert_feedback_with_string (fun () => By magic it suffices to show that (True)) Warning
+"Please come back later to prove that it suffices to show that True".
+Abort.

--- a/tests/tactics/Postpone.v
+++ b/tests/tactics/Postpone.v
@@ -64,3 +64,11 @@ Goal False.
   assert_feedback_with_string (fun () => By magic it suffices to show that (True)) Warning
 "Please come back later to prove that it suffices to show that True".
 Abort.
+
+(** Test 5: Cannot close proof after use of magic. *)
+Goal True.
+Proof.
+  By magic we conclude that (True).
+  Fail (). (* No remaining goals. *)
+  Fail Qed. (* Some goals given up. *)
+Abort.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -358,4 +358,16 @@ Use y := 2%nat in (i).
   exact I.
 Qed.
 
+(** Test 25 : Fail to close proof is blank is left in proof. *)
+Goal (∀ y ≤ 3%nat, True) -> True.
+Proof.
+  intro H.
+  Use y := _ in (H).
+  { Indeed, (?y <= 3)%nat. }
+  It holds that (True).
+  We conclude that (True).
+  Fail ().  (* No goals remaining. *)
+  Fail Qed. (* Cannot close proof. *)
+Abort.
+
 Close Scope subset_scope.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -66,13 +66,15 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
     | [ |- ex ?a] =>
       check_binder_warn a s true;
       set ($s := $t);
+      unfold subset_type in $s;
       let v := Control.hyp s in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
       match Constr.has_evar t with
       | true =>
         rename_blank_evars_in_term (Ident.to_string s) t;
         warn (concat_list [of_string "Please come back later to make a definitive choice for "; of_ident s; of_string "."; fnl ();
-        of_string "For now you can use that "; of_constr constr:($v = $t); of_string "."])
+        of_string "For now you can use that "; of_constr constr:($v = $t); of_string "."]);
+        assert_fix_earlier_warning ()
       | _ => ()
       end;
       exists $v;
@@ -151,6 +153,7 @@ Ltac2 choose_variable_in_exists_no_renaming (t:constr) :=
       |  true =>
         rename_blank_evars_in_term name t;
         warn (concat_list [of_string "Please come back later to make a definite choice."]);
+        assert_fix_earlier_warning ();
         eexists $t
       |  false => exists $t
       end

--- a/theories/Tactics/Conclusion.v
+++ b/theories/Tactics/Conclusion.v
@@ -110,19 +110,12 @@ Local Ltac2 guarantee_stated_goal_matches (sttd_goal : constr) :=
 (** Attempts to solve current goal.
 
   If argument [postpone] is [true], actually solving the goal is postponed.
-  The goal is shelved using an evar.
+  The goal is given up using admitted.
 *)
 Local Ltac2 conclude (postpone : bool) :=
   if postpone
     then
-      (* Postpone solving current goal using evar *)
-      (* (using admit gave confusing 'warning' ) *)
       let g := Control.goal () in
-      (* assert
-      let evar_id := Fresh.in_goal @_Hpostpone in
-      ltac1:(id claim |- evar (id : claim)) (Ltac1.of_ident evar_id) (Ltac1.of_constr g);
-      let evar := Control.hyp evar_id in
-      exact $evar;*)
       warn (concat_list [of_string "Please come back later to provide an actual proof of ";
         of_constr g; of_string "."]);
       admit

--- a/theories/Tactics/Conclusion.v
+++ b/theories/Tactics/Conclusion.v
@@ -118,12 +118,14 @@ Local Ltac2 conclude (postpone : bool) :=
       (* Postpone solving current goal using evar *)
       (* (using admit gave confusing 'warning' ) *)
       let g := Control.goal () in
+      (* assert
       let evar_id := Fresh.in_goal @_Hpostpone in
       ltac1:(id claim |- evar (id : claim)) (Ltac1.of_ident evar_id) (Ltac1.of_constr g);
       let evar := Control.hyp evar_id in
-      exact $evar;
+      exact $evar;*)
       warn (concat_list [of_string "Please come back later to provide an actual proof of ";
-        of_constr g; of_string "."])
+        of_constr g; of_string "."]);
+      admit
     else
       (* Attempt to solve current goal *)
       let err_msg (g : constr) := concat_list

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -56,7 +56,7 @@ Local Ltac2 try_out_label (label : ident) :=
   identifier starting with '_H' is generated.
 
   Additionally, if argument [postpone] is [true], actually proving the claim is postponed.
-  The claim is asserted and the proof is shelved using an evar.
+  The claim is asserted and the proof is given up on using admit.
   *)
 Local Ltac2 wp_assert (claim : constr) (label : ident option) (postpone : bool):=
   let err_msg (g : constr) := concat_list
@@ -70,14 +70,8 @@ Local Ltac2 wp_assert (claim : constr) (label : ident option) (postpone : bool):
   let claim := correct_type_by_wrapping claim in
   if postpone
     then
-      (* Assert claim and proof using shelved evar *)
-      (* (using 'admit' would have shown a confusing warning message) *)
       assert $claim as $id;
       Control.focus 1 1 (fun () =>
-        (* let evar_id := Fresh.in_goal @_Hpostpone in
-        ltac1:(id claim |- evar (id : claim)) (Ltac1.of_ident evar_id) (Ltac1.of_constr claim);
-        let evar := Control.hyp evar_id in
-        exact $evar*)
         admit
         );
       warn (concat_list [of_string "Please come back later to provide an actual proof of ";
@@ -216,7 +210,7 @@ Ltac2 Notation "It" "holds" "that" claim(constr) label(opt(seq("(", ident, ")"))
 
 
 (** * By magic it holds that ... (...)
-  Asserts a claim and proves it using a shelved evar.
+  Asserts a claim and gives up on proof using admit.
 
   Arguments:
     - [label: ident option], optional name for the claim.

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -74,10 +74,11 @@ Local Ltac2 wp_assert (claim : constr) (label : ident option) (postpone : bool):
       (* (using 'admit' would have shown a confusing warning message) *)
       assert $claim as $id;
       Control.focus 1 1 (fun () =>
-        let evar_id := Fresh.in_goal @_Hpostpone in
+        (* let evar_id := Fresh.in_goal @_Hpostpone in
         ltac1:(id claim |- evar (id : claim)) (Ltac1.of_ident evar_id) (Ltac1.of_constr claim);
         let evar := Control.hyp evar_id in
-        exact $evar
+        exact $evar*)
+        admit
         );
       warn (concat_list [of_string "Please come back later to provide an actual proof of ";
         of_constr claim; of_string "."])

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -291,7 +291,8 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
       | true => ()
       | false => warn (concat_list (
           [of_string "Please come back to this line later to make a definite choice for ";
-            _of_idents evars; of_string "."]))
+            _of_idents evars; of_string "."]));
+          assert_fix_earlier_warning ()
       end;
       (* Rename the blank evars in the terms supplied by the user,
         in such a way that the base name is derived from the binder name. *)
@@ -447,7 +448,8 @@ Local Ltac2 wp_specialize' (var_choice_list : (ident * constr) list) (h:constr) 
   | true => ()
   | false => warn (concat_list (
       [of_string "Please come back to this line later to make a definite choice for ";
-        _of_idents evars; of_string "."]))
+        _of_idents evars; of_string "."]));
+      assert_fix_earlier_warning ()
   end;
   lazy_match! statement with
     | _ -> ?x => (* Exclude matching on functions (naming codomain necessary) *)

--- a/theories/Util/Goals.v
+++ b/theories/Util/Goals.v
@@ -212,3 +212,23 @@ Ltac2 case (t:constr) :=
   end.
 
 Ltac2 Notation "Case" t(constr) := case t.
+
+(**
+  A goal to remind the reader to go back to an earlier
+  warning
+*)
+
+Inductive fix_earlier_warning : Prop :=.
+
+Notation "'Fix' 'an' 'earlier' 'warning'" := fix_earlier_warning.
+
+(**
+Intended for use in combination with magic:
+Adds a custom "False" as a shelved goal, so the
+proof cannot be finished without removing the warning.
+*)
+Ltac2 assert_fix_earlier_warning () :=
+  let w := Fresh.in_goal @__aux in
+  assert fix_earlier_warning as $w;
+  Control.focus 1 1 (fun () => admit);
+  clear $w.


### PR DESCRIPTION
There was be a bug that sometimes the goal could be closed after having chosen a blank, or after using magic. This is now fixed by adding a goal (a custom version of `False`) and admitting it.