### PR TITLE
Possible fix for automatically resolving evars

### DIFF
--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -25,7 +25,7 @@ Require Import Waterproof.Tactics.
 Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 Require Import Waterproof.Notations.Sets.
-
+Require Import Waterproof.Notations.Common.
 Waterproof Enable Redirect Feedback.
 
 (** Test 0: This should choose m equal to n *)
@@ -69,7 +69,7 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = ?n)."]).
+(n = !?n)."]).
 Abort.
 
 (** Test 6: Choose a named evar *)
@@ -85,7 +85,7 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = ?n)."]).
+(n = !?n)."]).
     assert (?n = 0).
 Abort.
 
@@ -95,15 +95,15 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_ + _ + _)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = ?n + ?n0 + ?n1)."]).
-    change (?n + ?n0 + ?n1 + 1 = ?n + ?n0 + ?n1 + 1).
+(n = !?n + !?n0 + !?n1)."]).
+    change (!?n + !?n0 + !?n1 + 1 = !?n + !?n0 + !?n1 + 1).
 Abort.
-
+Require Import Waterproof.Util.Evars.
 (** Test 9: Choose a blank without specifying the name of the variable *)
 Goal exists n : nat, n + 1 = n + 1.
   assert_feedback_with_string (fun () => Choose (_)) Warning
 "Please come back later to make a definite choice.".
-  change (?n + 1 = ?n + 1).
+  change (!?n + 1 = !?n + 1).
 Abort.
 
 (** Test 10: Choose a blank if binder has no name *)
@@ -175,4 +175,19 @@ Proof.
   * assert_constr_equal (Control.goal ()) constr:(VerifyGoal.Wrapper (le n ((S n)))).
     Indeed, (n ≤ S n)%nat.
   * We need to show that (INR(n) = 3).
+Abort.
+
+Close Scope R_scope.
+Open Scope nat_scope.
+
+(** Test 17 : The automation shouldn't resolve the evars *)
+
+Goal ∃ n ≥ 0, 3 = n.
+Proof.
+Choose n := _.
+* Fail Indeed, (n ≥ 0).
+  We need to verify that (n ≥ 0).
+  Control.shelve ().
+* We need to show that (3 = n).
+  Fail We conclude that (3 = n).
 Abort.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -69,7 +69,7 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = !?n)."]).
+(n = ?n?)."]).
 Abort.
 
 (** Test 6: Choose a named evar *)
@@ -85,7 +85,7 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = !?n)."]).
+(n = ?n?)."]).
     assert (?n = 0).
 Abort.
 
@@ -95,15 +95,15 @@ Goal exists n : nat, n + 1 = n + 1.
     assert_feedback_with_string (fun () => Choose n := (_ + _ + _)) Warning
 (String.concat "" ["Please come back later to make a definitive choice for n.
 For now you can use that "; "
-(n = !?n + !?n0 + !?n1)."]).
-    change (!?n + !?n0 + !?n1 + 1 = !?n + !?n0 + !?n1 + 1).
+(n = ?n? + ?n0? + ?n1?)."]).
+    change (?n? + ?n0? + ?n1? + 1 = ?n? + ?n0? + ?n1? + 1).
 Abort.
 Require Import Waterproof.Util.Evars.
 (** Test 9: Choose a blank without specifying the name of the variable *)
 Goal exists n : nat, n + 1 = n + 1.
   assert_feedback_with_string (fun () => Choose (_)) Warning
 "Please come back later to make a definite choice.".
-  change (!?n + 1 = !?n + 1).
+  change (?n? + 1 = ?n? + 1).
 Abort.
 
 (** Test 10: Choose a blank if binder has no name *)

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -115,7 +115,7 @@ Proof.
 intro H.
 assert_feedback_with_string (fun () => Use a := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for a.".
-It holds that (forall b c : nat, !?a + b + c = 0) (i).
+It holds that (forall b c : nat, ?a? + b + c = 0) (i).
 Abort.
 
 (** Test 8 : use multiple placeholders as variable names *)
@@ -124,7 +124,7 @@ Proof.
 intro H.
 assert_feedback_with_string (fun () => Use a := _, b := _, c := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for a, b, c.".
-It holds that (!?a + !?b + !?c = 0).
+It holds that (?a? + ?b? + ?c? = 0).
 Abort.
 
 (** Test 9 : use named placeholder: then renaming shouldn't happen *)
@@ -149,7 +149,7 @@ Proof.
 intro H.
 ltac1:(evar (e : nat)).
 Use a := (?e + _) in (H).
-It holds that (forall b : nat, ?e + !?a + b = 0) (i).
+It holds that (forall b : nat, ?e + ?a? + b = 0) (i).
 Abort.
 
 (** Test 12 : use an earlier introduced evar *)
@@ -157,9 +157,9 @@ Goal (forall a b : nat, a + b = 0) -> False.
 Proof.
 intro H.
 Use a := _ in (H).
-It holds that (forall b : nat, !?a + b = 0) (i).
-Use b := !?a in (i).
-It holds that (!?a + !?a = 0).
+It holds that (forall b : nat, ?a? + b = 0) (i).
+Use b := ?a? in (i).
+It holds that (?a? + ?a? = 0).
 Abort.
 
 (** Test 13 : TODO: illustration of slightly strange behavior : was fixed with
@@ -198,9 +198,9 @@ Proof.
 intro H.
 assert_feedback_with_strings (fun () => Use x := _ in (H)) Warning
 ["Please come back to this line later to make a definite choice for x."].
-* We need to verify that (!?x ∈ B).
+* We need to verify that (?x? ∈ B).
   Control.shelve ().
-* It holds that (!?x = 0).
+* It holds that (?x? = 0).
 Abort.
 
 (** Test 16 : Specialize variables in a long statements
@@ -240,11 +240,11 @@ intro H.
 assert_feedback_with_strings (fun () => Use x := _, y := _, z := _ in (H))
   Warning
 ["Please come back to this line later to make a definite choice for x, y, z."].
-* We need to verify that (!?x ∈ B).
+* We need to verify that (?x? ∈ B).
   Control.shelve ().
-* We need to verify that (!?z ∈ D).
+* We need to verify that (?z? ∈ D).
   Control.shelve ().
-* It holds that (1 = 1 -> !?x = !?y + !?z).
+* It holds that (1 = 1 -> ?x? = ?y? + ?z?).
 Abort.
 
 (** Test 19: have a set that depends on an earlier set*)
@@ -367,8 +367,8 @@ Goal (∀ x > 2, x = 0) -> True.
 Proof.
 intro i.
 Use x := _ in (i).
-* Fail Indeed, (!?x > 2).
-  We need to verify that (!?x > 2).
+* Fail Indeed, (?x? > 2).
+  We need to verify that (?x? > 2).
   Control.shelve ().
 Abort.
 

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -23,6 +23,7 @@ Require Import Waterproof.Tactics.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Util.Assertions.
 Require Import Waterproof.Util.MessagesToUser.
+Require Import Waterproof.Notations.Common.
 
 Waterproof Enable Redirect Feedback.
 
@@ -114,7 +115,7 @@ Proof.
 intro H.
 assert_feedback_with_string (fun () => Use a := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for a.".
-It holds that (forall b c : nat, ?a + b + c = 0) (i).
+It holds that (forall b c : nat, !?a + b + c = 0) (i).
 Abort.
 
 (** Test 8 : use multiple placeholders as variable names *)
@@ -123,7 +124,7 @@ Proof.
 intro H.
 assert_feedback_with_string (fun () => Use a := _, b := _, c := _ in (H)) Warning
 "Please come back to this line later to make a definite choice for a, b, c.".
-It holds that (?a + ?b + ?c = 0).
+It holds that (!?a + !?b + !?c = 0).
 Abort.
 
 (** Test 9 : use named placeholder: then renaming shouldn't happen *)
@@ -148,7 +149,7 @@ Proof.
 intro H.
 ltac1:(evar (e : nat)).
 Use a := (?e + _) in (H).
-It holds that (forall b : nat, ?e + ?a + b = 0) (i).
+It holds that (forall b : nat, ?e + !?a + b = 0) (i).
 Abort.
 
 (** Test 12 : use an earlier introduced evar *)
@@ -156,9 +157,9 @@ Goal (forall a b : nat, a + b = 0) -> False.
 Proof.
 intro H.
 Use a := _ in (H).
-It holds that (forall b : nat, ?a + b = 0) (i).
-Use b := ?a in (i).
-It holds that (?a + ?a = 0).
+It holds that (forall b : nat, !?a + b = 0) (i).
+Use b := !?a in (i).
+It holds that (!?a + !?a = 0).
 Abort.
 
 (** Test 13 : TODO: illustration of slightly strange behavior : was fixed with
@@ -197,9 +198,9 @@ Proof.
 intro H.
 assert_feedback_with_strings (fun () => Use x := _ in (H)) Warning
 ["Please come back to this line later to make a definite choice for x."].
-* We need to verify that (?x ∈ B).
+* We need to verify that (!?x ∈ B).
   Control.shelve ().
-* It holds that (?x = 0).
+* It holds that (!?x = 0).
 Abort.
 
 (** Test 16 : Specialize variables in a long statements
@@ -239,11 +240,11 @@ intro H.
 assert_feedback_with_strings (fun () => Use x := _, y := _, z := _ in (H))
   Warning
 ["Please come back to this line later to make a definite choice for x, y, z."].
-* We need to verify that (?x ∈ B).
+* We need to verify that (!?x ∈ B).
   Control.shelve ().
-* We need to verify that (?z ∈ D).
+* We need to verify that (!?z ∈ D).
   Control.shelve ().
-* It holds that (1 = 1 -> ?x = ?y + ?z).
+* It holds that (1 = 1 -> !?x = !?y + !?z).
 Abort.
 
 (** Test 19: have a set that depends on an earlier set*)
@@ -357,5 +358,18 @@ Use y := 2%nat in (i).
 * It holds that (INR 2 = 0).
   exact I.
 Qed.
+
+(** Test 25 : The automation shouldn't resolve the evars... *)
+
+Close Scope R_scope.
+
+Goal (∀ x > 2, x = 0) -> True.
+Proof.
+intro i.
+Use x := _ in (i).
+* Fail Indeed, (!?x > 2).
+  We need to verify that (!?x > 2).
+  Control.shelve ().
+Abort.
 
 Close Scope subset_scope.

--- a/theories/Notations/Common.v
+++ b/theories/Notations/Common.v
@@ -71,5 +71,5 @@ Notation "'Derive' 'a' 'contradiction.'" := (False)
 Definition identity_seal {T : Type} (x : T) : T.
 exact x. Qed.
 
-Notation "! x" := (identity_seal x) (at level 1, x at next level,
-  format "! x").
+Notation "x ?" := (identity_seal x) (at level 1,
+  format "x ?").

--- a/theories/Notations/Common.v
+++ b/theories/Notations/Common.v
@@ -67,3 +67,9 @@ Notation "¬ x" := (~x) (at level 75, right associativity) : type_scope.
 
 Notation "'Derive' 'a' 'contradiction.'" := (False)
   (only printing).
+
+Definition identity_seal {T : Type} (x : T) : T.
+exact x. Qed.
+
+Notation "! x" := (identity_seal x) (at level 1, x at next level,
+  format "! x").

--- a/theories/Util/Evars.v
+++ b/theories/Util/Evars.v
@@ -19,6 +19,7 @@
 Require Export Ltac2.Ltac2.
 
 Require Import Waterproof.Waterproof.
+Require Import Waterproof.Notations.Common.
 
 Ltac2 @ external refine_goal_with_evar : string -> unit := "coq-waterproof" "refine_goal_with_evar_external".
 
@@ -28,4 +29,6 @@ Ltac2 rename_blank_evars_in_term (base_name : string) (x : constr) :=
   let evars := blank_evars_in_term x in
   let m := List.length evars in
   List.fold_left (fun _ ev => Control.new_goal ev) (evars) ();
-  Control.focus 2 (Int.add m 1) (fun () => refine_goal_with_evar base_name; Control.shelve()).
+  Control.focus 2 (Int.add m 1) (fun () =>
+    ltac1:(refine (identity_seal _));
+    refine_goal_with_evar base_name; Control.shelve()).


### PR DESCRIPTION
This seems to fix the problem with evars that get automatically resolved, at the expense of a slightly more complicated notation (`!?n` rather than `?n`). Different choices for the notation could be made.

Edit: in later commit, suggested the notation `?n?` over `!?n`.