### PR TITLE
Split unfold messages so the behavior in the editor is better

### DIFF
--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -75,8 +75,8 @@ Proof.
   (fun () => Expand the definition of foo in (foo = 4))
 "Remove this line in the final version of your proof.")
   Info
-["result:
-  (0 = 4)"].
+["Result:";
+  "(0 = 4)"].
 Abort.
 
 (* Test 4: Unfold term in given statement that matches goal,
@@ -90,8 +90,8 @@ Proof.
   (fun () => Expand the definition of foo in (foo = 1))
 "Remove this line in the final version of your proof.")
   Info
-["replace line with:
-  We need to show that (0 = 1)."].
+["Replace line with:";
+  "We need to show that (0 = 1)."].
 Abort.
 
 (* Test 5: Unfold term in given statement that matches hypothesis,
@@ -105,8 +105,8 @@ Proof.
   (fun () => Expand the definition of foo in (foo = 0))
 "Remove this line in the final version of your proof.")
   Info
-["replace line with:
-  It holds that (0 = 0)."].
+["Replace line with:";
+  "It holds that (0 = 0)."].
 Abort.
 
 

--- a/theories/Tactics/Unfold.v
+++ b/theories/Tactics/Unfold.v
@@ -64,24 +64,24 @@ Ltac2 unfold_in_statement (unfold_method: constr -> constr)
       match Constr.equal g statement with
       | false => Control.zero Inner
       | true =>
+        print (of_string "Replace line with:");
         let msg (unfolded : constr) := concat_list
-          [of_string "replace line with:
-  We need to show that "; of_constr unfolded; of_string "."] in
+          [of_string "We need to show that "; of_constr unfolded; of_string "."] in
         print (msg unfolded_statement)
       end
     | [_ : ?hyp |- _ ] =>
       match Constr.equal hyp statement with
       | false => Control.zero Inner
       | true =>
+        print (of_string "Replace line with:");
         let msg (unfolded : constr) := concat_list
-          [of_string "replace line with:
-  It holds that "; of_constr unfolded; of_string "."] in
+          [of_string "It holds that "; of_constr unfolded; of_string "."] in
         print (msg unfolded_statement)
       end
     | [ |- _ ] =>
+      print (of_string "Result:");
       let msg (unfolded : constr) := concat_list
-      [of_string "result:
-  "; of_constr unfolded] in
+      [of_constr unfolded] in
       print (msg unfolded_statement)
     end
   | true =>


### PR DESCRIPTION
Small fix to improve the interlacing with the editor on certain types of unfold messages.