### PR TITLE
Prevent automatic rewriting of terms in proof goal matching new definition.

### DIFF
--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -158,21 +158,19 @@ Proof.
 Abort.
 
 (** Test 15: Choose a natural number less than a number, but in R_scope *)
-(* TODO: the goal here becomes strange *)
 Goal ∃ n < 4%nat, INR(n) = 3.
 Proof.
   Choose n := 2%nat.
-  * assert_constr_equal (Control.goal ()) constr:(VerifyGoal.Wrapper (lt n (S (S n)))).
-    Indeed, ((n < S (S n))%nat).
+  * assert_constr_equal (Control.goal ()) constr:(VerifyGoal.Wrapper (n < 4)%nat).
+    Indeed, ((n < 4)%nat).
   * We need to show that (INR(n) = 3).
 Abort.
 
 (** Test 16: Choose a natural number less than or equal to a number, but in R_scope *)
-(* TODO: the goal here becomes strange *)
 Goal ∃ n ≤ 4%nat, INR(n) = 3.
 Proof.
   Choose n := 3%nat.
-  * assert_constr_equal (Control.goal ()) constr:(VerifyGoal.Wrapper (le n ((S n)))).
-    Indeed, (n ≤ S n)%nat.
+  * assert_constr_equal (Control.goal ()) constr:(VerifyGoal.Wrapper (n ≤ 4)%nat).
+    Indeed, (n ≤ 4)%nat.
   * We need to show that (INR(n) = 3).
 Abort.

--- a/theories/Libs/Analysis/LimsupLiminfBolzano.v
+++ b/theories/Libs/Analysis/LimsupLiminfBolzano.v
@@ -109,6 +109,7 @@ Proof.
     We need to show that
       (a n ≤ (let (a0, _) := ub_to_lub (fun k ↦ (a (N₀ + k)%nat), maj_ss a N₀ (i)) in a0)).
     Define ii := (ub_to_lub (fun (k : ℕ) ↦ a (N₀ +k)%nat) (maj_ss a N₀ (i))).
+    We need to show that (a(n) ≤ (let (a0, _) := ii in a0)).
     clear _defeq.
     Obtain such an l. It holds that
       (is_lub (EUn (fun (k : ℕ) ↦ a (N₀ +k)%nat)) l).
@@ -118,6 +119,7 @@ Proof.
       and (for all b : ℝ, Raxioms.is_upper_bound (EUn (fun k ↦ (a (N₀ + k)%nat)), b) ⇨ l ≤ b) hold.
     It holds that (for all x : ℝ, EUn (fun k ↦ (a (N₀ + k)%nat), x) ⇨ x ≤ l).
     It holds that (N₀ + (n-N₀) = n)%nat.
+
     It suffices to show that (EUn (fun (k : ℕ) ↦ (a (N₀ + k)%nat)) (a n)).
     We need to show that (there exists k : ℕ, a n = a (N₀ + k)%nat).
     We need to show that (∃ k : ℕ, a n = a (N₀ + k)%nat).
@@ -256,6 +258,7 @@ Proof.
       Assume that (is_seq_acc_pt a x).
       By acc_pt_bds_seq_ub it holds that (∀ m : ℕ, x ≤ sequence_ub a (i) m).
       Define iii := (lim_sup_bdd a (i) (ii)).
+      We need to show that (x ≤ proj1_sig (_,_,iii)).
       clear _defeq.
       Obtain such an l. simpl.
       By (low_bd_seq_is_low_bd_lim (sequence_ub a (i)))

--- a/theories/Libs/Analysis/SequentialAccumulationPoints.v
+++ b/theories/Libs/Analysis/SequentialAccumulationPoints.v
@@ -69,7 +69,7 @@ Proof.
     Take k : ℕ.
     It suffices to show that (there exists k0 : nat, a k = a k0).
     Choose k0 := k.
-    We conclude that (a k0 = a k0).
+    We conclude that (a k = a k0).
   }
   Take k ∈ ℕ.
   By (v) it holds that (a(n k) ≤ M).

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -765,6 +765,7 @@ Proof.
     We need to show that (∀ ε > 0,
       there exists k : ℕ, a k > (let (a0, _) := ub_to_lub a (i) in a0) - ε).
     Define lub_a_prf := (ub_to_lub a (i)).
+    We need to show that (∀ ε > 0, ∃ k, a(k) > (let (a0, _) := lub_a_prf in a0) - ε).
     clear _defeq. Obtain such an l.
     Take ε > 0.
     We claim that (is_sup (EUn a) l).
@@ -777,6 +778,7 @@ Proof.
     It holds that (there exists n : ℕ , y = a n).
     Obtain such an n.
     Choose k := n.
+    simpl.
     We need to show that (l - ε < a n).
     We conclude that (& l - ε < y = a n).
 Qed.

--- a/theories/Tactics/Choose.v
+++ b/theories/Tactics/Choose.v
@@ -65,7 +65,7 @@ Ltac2 choose_variable_in_exists_goal_with_renaming (s:ident) (t:constr) :=
   lazy_match! goal with
     | [ |- ex ?a] =>
       check_binder_warn a s true;
-      set ($s := $t);
+      pose ($s := $t);
       let v := Control.hyp s in
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
       match Constr.has_evar t with

--- a/theories/Tactics/Define.v
+++ b/theories/Tactics/Define.v
@@ -31,7 +31,7 @@ Require Import Util.Goals.
     - defines [t] as [u].
 *)
 Local Ltac2 defining (u: ident) (t: constr) :=
-  set ($u := $t);
+  pose ($u := $t);
   let u_constr := Control.hyp u in 
   let w := Fresh.fresh (Fresh.Free.of_goal ()) @_defeq in
   assert ($w : $u_constr = $t) by reflexivity.

--- a/theories/Tactics/Specialize.v
+++ b/theories/Tactics/Specialize.v
@@ -277,7 +277,7 @@ Local Ltac2 wp_specialize (var_choice_list : (ident * constr) list) (h:constr) :
           | None => Fresh.fresh (Fresh.Free.of_goal ()) @_aux_sp_
           | Some temp_id => Fresh.fresh (Fresh.Free.of_goal ()) temp_id
           end in
-          set ($aux_x := $c);
+          pose ($aux_x := $c);
           (i, aux_x)) var_choice_list in
       let wrapped_var_choice_list :=
         List.map (fun (i, aux_x) => (i, Control.hyp aux_x)) def_list in


### PR DESCRIPTION
by replacing `set a := x` by `pose a := x`