### PR TITLE
Small fixes

### DIFF
--- a/coq-waterproof.opam
+++ b/coq-waterproof.opam
@@ -33,7 +33,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 
-available: arch != "s390x"
+available: (arch != "s390x") & (arch != "ppc64") & (os != "win32")
 
 tags: [
   "keyword:mathematics education"

--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -196,3 +196,27 @@ Proof.
   intros.
   _internal_ Expand the definition of foo2 in (foo = 8).
 Abort.
+
+(* Test 14: added test for a previous bug with "expand the definition in" *)
+Require Import Coq.Reals.Reals.
+Require Import Waterproof.Notations.Common.
+Require Import Waterproof.Notations.Reals.
+Require Import Waterproof.Notations.Sets.
+Require Import Waterproof.Libs.Analysis.Sequences.
+
+Require Import Waterproof.Util.MessagesToUser.
+Require Import Waterproof.Util.Assertions.
+
+Local Parameter a : ℕ → ℝ.
+
+Lemma example :
+  (a is _bounded_)
+    ⇔
+  (a is _bounded above_ ∧ a is _bounded below_).
+Proof.
+assert_feedback_with_strings (fun () =>
+  assert_fails_with_string (fun () => Expand the definition of bounded above in
+  (a is _bounded above_)) "Remove this line in the final version of your proof.")
+  Notice
+["Result:";"(∃ M ∈ ℝ, ∀ n ∈ ℕ, (a(n) ≤ M)%R)"].
+Abort.

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -36,7 +36,7 @@ Definition open_ball (p : R) (r : R) : subset R := as_subset _ (fun x => | x - p
 Definition is_interior_point (a : R) (A : R -> Prop) :=
   ∃ r > 0, ∀ x ∈ (open_ball a r), x ∈ A.
 
-Definition is_open (A : R -> Prop) := for all a : R, A a -> is_interior_point a A.
+Definition is_open (A : R -> Prop) := ∀ a ∈ A, is_interior_point a A.
 
 Definition complement (A : R -> Prop) : subset R := as_subset _ (fun x => not (A x)).
 

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -413,12 +413,10 @@ Definition is_bounded (a : ℕ → ℝ) :=
 Notation "a 'is' '_bounded_'" := (is_bounded a) (at level 20).
 Notation "a 'is' 'bounded'" := (is_bounded a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded (statement : constr) := eval unfold is_bounded in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded (Some "bounded") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded (Some "bounded") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded (Some "bounded") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded (Some "bounded") false x.
 
 Definition is_bounded_equivalent (a : ℕ → ℝ) :=
   ∃ M > 0, ∀ n ∈ ℕ, |a n| ≤ M.
@@ -479,24 +477,20 @@ Definition is_bounded_above (a : ℕ → ℝ) :=
 Notation "a 'is' '_bounded' 'above_'" := (is_bounded_above a) (at level 20).
 Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_above (statement : constr) := eval unfold is_bounded_above in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_above (Some "bounded above") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_above (Some "bounded above") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded_above (Some "bounded above") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded_above (Some "bounded above") false x.
 
 Definition is_bounded_below (a : ℕ → ℝ) :=
   ∃ m ∈ ℝ, ∀ n ∈ ℕ, m ≤ a(n).
 Notation "a 'is' '_bounded' 'below_'" := (is_bounded_below a) (at level 20).
 Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 20, only parsing).
 Local Ltac2 unfold_is_bounded_below (statement : constr) := eval unfold is_bounded_below in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_below (Some "bounded below") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_is_bounded_below (Some "bounded below") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", constr))):=
+  wp_unfold unfold_is_bounded_below (Some "bounded below") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_is_bounded_below (Some "bounded below") false x.
 
 (** Convergence to +∞ and -∞. *)
 Definition diverges_to_plus_infinity (a : ℕ → ℝ) :=
@@ -509,18 +503,14 @@ Notation "a '_diverges' 'to' '∞_'" := (diverges_to_plus_infinity a) (at level 
 Notation "a 'diverges' 'to' '∞'"   := (diverges_to_plus_infinity a) (at level 20, only parsing).
 Local Ltac2 unfold_diverge_plus_infty (statement : constr) :=
   eval unfold diverges_to_plus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_plus_infty (Some "⟶ ∞") false.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_plus_infty (Some "diverges to ∞") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_plus_infty (Some "⟶ ∞") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_plus_infty (Some "⟶ ∞") false x.
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_plus_infty (Some "diverges to ∞") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_plus_infty (Some "diverges to ∞") false x.
 
 
 Definition diverges_to_minus_infinity (a : ℕ → ℝ) :=
@@ -533,17 +523,13 @@ Notation "a '_diverges' 'to' '-∞_'" := (diverges_to_minus_infinity a) (at leve
 Notation "a 'diverges' 'to' '-∞'"   := (diverges_to_minus_infinity a) (at level 20, only parsing).
 Local Ltac2 unfold_diverge_minus_infty (statement : constr) :=
   eval unfold diverges_to_minus_infinity in $statement.
-Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞":=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_minus_infty (Some "⟶ -∞") false.
-Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") true.
-Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", "()"))) :=
-  panic_if_goal_wrapped ();
-  unfold_in_all unfold_diverge_minus_infty (Some "diverges to -∞") false.
+Ltac2 Notation "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", constr))):=
+  wp_unfold unfold_diverge_minus_infty (Some "⟶ -∞") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "⟶" "-∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_minus_infty (Some "⟶ -∞") false x.
+Ltac2 Notation "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_minus_infty (Some "diverges to -∞") true x.
+Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "diverges" "to" "-∞" x(opt(seq("in", constr))) :=
+  wp_unfold unfold_diverge_minus_infty (Some "diverges to -∞") false x.
 
 Close Scope R_scope.


### PR DESCRIPTION
* Excludes certain architectures / operating systems in the opam file
* Fixes an old definition of open
* Fixes #99 . That issue seems to only occur for definitions in this particular file (`Sequences.v`): it was not adapted yet to give it full functionality with the new unfold syntax.