### PR TITLE
Fix docker image

### DIFF
--- a/.github/workflows/build-with-make.yml
+++ b/.github/workflows/build-with-make.yml
@@ -24,5 +24,5 @@ jobs:
             chmod -R 777 ./
             CURRENT_DIRECTORY=$(pwd)
             echo "Current directory: $CURRENT_DIRECTORY"
-            su - coq -c "cd $CURRENT_DIRECTORY && pwd && make"
-            su - coq -c "cd $CURRENT_DIRECTORY && pwd && make install"
+            su - rocq -c "cd $CURRENT_DIRECTORY && pwd && make"
+            su - rocq -c "cd $CURRENT_DIRECTORY && pwd && make install"

--- a/.github/workflows/build-with-make.yml
+++ b/.github/workflows/build-with-make.yml
@@ -12,7 +12,7 @@ jobs:
     name: build with make
     runs-on: ubuntu-latest
     container:
-      image: coqorg/coq:dev-ocaml-4.14.2-flambda
+      image: rocq/rocq-prover:dev-ocaml-4.14.2-flambda
       options: --user root
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - name: Set up git repository
         uses: actions/checkout@v3
-      
+
       - name: Build plugin
         uses: coq-community/docker-coq-action@v1
         with:
-          custom_image: 'coqorg/coq:dev-ocaml-4.14.2-flambda'
+          custom_image: 'rocq/rocq-prover:dev-ocaml-4.14.2-flambda'
           opam_file: 'coq-waterproof.opam'
           before_script: |
             startGroup "Install dependencies"


### PR DESCRIPTION
In the CI, now pull the dev docker image from rocq/rocq-prover because it is no longer available at the previous repository.