### PR TITLE
Fix warnings from 8.20

### DIFF
--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -184,9 +184,9 @@ End metricspace.
 #[export] Hint Resolve <- alt_char_continuity : wp_reals.
 
 (** Notations *)
-Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at level 68).
+Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at level 69).
 
-Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
+Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 69, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
@@ -195,9 +195,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
   wp_unfold unfold_acc_point (Some "accumulation point") false x.
 
-Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
+Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 69).
 
-Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68, only parsing).
+Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 69, only parsing).
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
@@ -206,9 +206,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
   wp_unfold unfold_isol_point (Some "isolated point") false x.
 
-Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68).
+Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 69).
 
-Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 68, only parsing).
+Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point _ f a L) (at level 69, only parsing).
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
@@ -218,9 +218,9 @@ Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("
   wp_unfold unfold_lim_in_point (Some "limit") false x.
 
 
-Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 68).
+Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in _ f a) (at level 69).
 
-Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in _ f a)  (at level 68, only parsing).
+Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in _ f a)  (at level 69, only parsing).
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -102,9 +102,9 @@ Qed.
 #[export] Hint Resolve <- alt_char_continuity : wp_reals.
 
 (** Notations *)
-Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at level 68).
+Notation "a 'is' 'an' '_accumulation' 'point_'" := (is_accumulation_point a) (at level 69).
 
-Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 68, only parsing).
+Notation "a 'is' 'an' 'accumulation' 'point'" := (is_accumulation_point a) (at level 69, only parsing).
 
 Local Ltac2 unfold_acc_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation" "point" x(opt(seq("in", constr))) :=
@@ -113,9 +113,9 @@ Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "accumulation" "poi
   wp_unfold unfold_acc_point (Some "accumulation point") false x.
 
 
-Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 68).
+Notation "a 'is' 'an' '_isolated' 'point_'" := (is_isolated_point a) (at level 69).
 
-Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 68, only parsing).
+Notation "a 'is' 'an' 'isolated' 'point'" := (is_isolated_point a) (at level 69, only parsing).
 
 Local Ltac2 unfold_isol_point (statement : constr) := eval unfold is_isolated_point in $statement.
 
@@ -124,9 +124,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "isolated" "point" x(opt(seq("in", constr))) :=
   wp_unfold unfold_isol_point (Some "isolated point") false x.
 
-Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68).
+Notation "'_limit_' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 69).
 
-Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 68, only parsing).
+Notation "'limit' 'of' f 'in' a 'is' L" := (limit_in_point f a L) (at level 69, only parsing).
 
 Local Ltac2 unfold_lim_in_point (statement : constr) := eval unfold limit_in_point in $statement.
 
@@ -136,9 +136,9 @@ Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "limit" x(opt(seq("
   wp_unfold unfold_lim_in_point (Some "limit") false x.
 
 
-Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in f a) (at level 68).
+Notation "f 'is' '_continuous_' 'in' a" := (is_continuous_in f a) (at level 69).
 
-Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in f a)  (at level 68, only parsing).
+Notation "f 'is' 'continuous' 'in' a" := (is_continuous_in f a)  (at level 69, only parsing).
 
 Local Ltac2 unfold_is_cont (statement : constr) := eval unfold is_continuous_in in $statement.
 

--- a/theories/Libs/Analysis/MetricSpaces.v
+++ b/theories/Libs/Analysis/MetricSpaces.v
@@ -52,7 +52,9 @@ Definition dist_non_degenerate :
   (dist X x y = 0) ⇒ (x = y).
 Proof.
   Take x, y ∈ X.
-  By (proj1(_,_,(dist_refl X x y))) we conclude that (dist X x y = 0 ⇨ x = y).
+  Assume that (dist X x y = 0).
+  pose (proj1(_, _, (dist_refl X x y))) as i.
+  By (i) we conclude that (x = y).
 Defined.
 
 Definition dist_symmetric :
@@ -68,13 +70,14 @@ Definition dist_triangle_inequality :
   dist X x z ≤ dist X x y + dist X y z.
 Proof.
   Take x, y, z ∈ X.
-  By (dist_tri X) we conclude that (dist X x z ≤ dist X x y + dist X y z).
+  By (dist_tri) we conclude that (dist X x z ≤ dist X x y + dist X y z).
 Qed.
 
 Definition dist_reflexive : ∀ x ∈ X, dist X x x = 0.
 Proof.
   Take x ∈ X.
-  By (proj2(_, _, (dist_refl X x x))) we conclude that (dist X x x = 0).
+  pose (proj2(_, _, (dist_refl X x x))) as i.
+  By (i) we conclude that (dist X x x = 0).
 Defined.
 
 End Definitions.

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -59,9 +59,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", co
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" "ball" x(opt(seq("in", constr))) :=
   wp_unfold unfold_open_ball (Some "open ball ") false x.
 
-Notation "a 'is' 'an' '_interior' 'point_' 'of' A" := (is_interior_point a A) (at level 68).
+Notation "a 'is' 'an' '_interior' 'point_' 'of' A" := (is_interior_point a A) (at level 69).
 
-Notation "a 'is' 'an' 'interior' 'point' 'of' A" := (is_interior_point a A) (at level 68, only parsing).
+Notation "a 'is' 'an' 'interior' 'point' 'of' A" := (is_interior_point a A) (at level 69, only parsing).
 
 Local Ltac2 unfold_is_interior_point (statement : constr) := eval unfold is_interior_point in $statement.
 
@@ -70,9 +70,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "interior" "point" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_interior_point (Some "interior point") false x.
 
-Notation "A 'is' '_open_'" := (is_open A) (at level 68).
+Notation "A 'is' '_open_'" := (is_open A) (at level 69).
 
-Notation "A 'is' 'open'" := (is_open A) (at level 68, only parsing).
+Notation "A 'is' 'open'" := (is_open A) (at level 69, only parsing).
 
 Local Ltac2 unfold_is_open (statement : constr) := eval unfold is_open in $statement.
 
@@ -83,7 +83,7 @@ Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "open" x(opt(seq("i
 
 Notation "'ℝ\' A" := (complement A) (at level 20, format "'ℝ\' A").
 
-Notation "'ℝ' '\' A" := (complement A) (at level 20, only parsing).
+Notation "'ℝ' '\' A" := (complement A) (at level 0, only parsing).
 
 Local Ltac2 unfold_complement (statement : constr) := eval unfold complement,
   as_subset in $statement.
@@ -98,9 +98,9 @@ Ltac2 Notation "Expand" "the" "definition" "of" "complement" x(opt(seq("in", con
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "complement" x(opt(seq("in", constr))) :=
   wp_unfold unfold_complement (Some "complement") false x.
 
-Notation "A 'is' '_closed_'" := (is_closed A) (at level 68).
+Notation "A 'is' '_closed_'" := (is_closed A) (at level 69).
 
-Notation "A 'is' 'closed'" := (is_closed A) (at level 68, only parsing).
+Notation "A 'is' 'closed'" := (is_closed A) (at level 69, only parsing).
 
 Local Ltac2 unfold_is_closed (statement : constr) := eval unfold is_closed in $statement.
 

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -410,8 +410,8 @@ Definition is_bounded (a : ℕ → ℝ) :=
     ∃ M > 0,
       ∀ n ∈ ℕ,
         |a n - q| ≤ M.
-Notation "a 'is' '_bounded_'" := (is_bounded a) (at level 20).
-Notation "a 'is' 'bounded'" := (is_bounded a) (at level 20, only parsing).
+Notation "a 'is' '_bounded_'" := (is_bounded a) (at level 69).
+Notation "a 'is' 'bounded'" := (is_bounded a) (at level 69, only parsing).
 Local Ltac2 unfold_is_bounded (statement : constr) := eval unfold is_bounded in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_bounded (Some "bounded") true x.
@@ -474,8 +474,8 @@ Qed.
 (** Definitions sequence bounded from above and below *)
 Definition is_bounded_above (a : ℕ → ℝ) :=
   ∃ M ∈ ℝ, ∀ n ∈ ℕ, a(n) ≤ M.
-Notation "a 'is' '_bounded' 'above_'" := (is_bounded_above a) (at level 20).
-Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 20, only parsing).
+Notation "a 'is' '_bounded' 'above_'" := (is_bounded_above a) (at level 69).
+Notation "a 'is' 'bounded' 'above'" := (is_bounded_above a) (at level 69, only parsing).
 Local Ltac2 unfold_is_bounded_above (statement : constr) := eval unfold is_bounded_above in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "above" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_bounded_above (Some "bounded above") true x.
@@ -484,8 +484,8 @@ Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "bounded" "above" x
 
 Definition is_bounded_below (a : ℕ → ℝ) :=
   ∃ m ∈ ℝ, ∀ n ∈ ℕ, m ≤ a(n).
-Notation "a 'is' '_bounded' 'below_'" := (is_bounded_below a) (at level 20).
-Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 20, only parsing).
+Notation "a 'is' '_bounded' 'below_'" := (is_bounded_below a) (at level 69).
+Notation "a 'is' 'bounded' 'below'" := (is_bounded_below a) (at level 69, only parsing).
 Local Ltac2 unfold_is_bounded_below (statement : constr) := eval unfold is_bounded_below in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "bounded" "below" x(opt(seq("in", constr))):=
   wp_unfold unfold_is_bounded_below (Some "bounded below") true x.

--- a/theories/Libs/Analysis/StrongInductionIndexSequence.v
+++ b/theories/Libs/Analysis/StrongInductionIndexSequence.v
@@ -343,7 +343,7 @@ Local Ltac2 inductive_def_index_seq_n () :=
     | Val _ =>
       Control.focus 1 1 (fun () => apply StrongIndIndxSeq.Base.unwrap);
       Control.focus 2 2 (fun () => apply StrongIndIndxSeq.Step.unwrap)
-    | Err exn => throw (of_string "The index sequence cannot be defined using this technique.")
+    | Err _ => throw (of_string "The index sequence cannot be defined using this technique.")
     end in
   lazy_match! goal with
   | [ |- ∃ n : nat -> nat, is_index_sequence n /\ ∀ k ∈ conv nat, @?p n k] => (*@?p*) apply_induction_principle p

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -41,9 +41,9 @@ Notation "'_index' 'sequence_'" := (is_index_sequence) (at level 69) : pred_for_
 Notation "'index' 'sequence'" := (is_index_sequence) (at level 69, only parsing) : metric_scope.
 Notation "'index' 'sequence'" := (is_index_sequence) (at level 69, only parsing) : pred_for_subset_scope.
 
-Notation "n 'is' 'an' '_index' 'sequence_'" := (is_index_sequence n) (at level 68) : metric_scope.
+Notation "n 'is' 'an' '_index' 'sequence_'" := (is_index_sequence n) (at level 69) : metric_scope.
 
-Notation "n 'is' 'an' 'index' 'sequence'" := (is_index_sequence n) (at level 68, only parsing) : metric_scope.
+Notation "n 'is' 'an' 'index' 'sequence'" := (is_index_sequence n) (at level 69, only parsing) : metric_scope.
 
 Local Ltac2 unfold_is_index_sequence (statement : constr) := eval unfold is_index_sequence in $statement.
 
@@ -60,7 +60,7 @@ Definition is_index_seq (n : ℕ → ℕ) :=
 
 Notation "a ◦ n" := (fun (k : nat) => a (n k)) (right associativity, at level 11).
 
-Notation "a ◦ n ◦ m" := (fun (k : nat) => a (n (m k))) (right associativity, at level 12).
+Notation "a ◦ n ◦ m" := (fun (k : nat) => a (n (m k))) (right associativity).
 
 Section my_section.
 Variable X : Metric_Space.
@@ -243,16 +243,16 @@ Qed.
 
 End my_section.
 
-Notation "b 'is' 'a' '_subsequence_' 'of' a" := (is_subsequence _ b a) (at level 68) : metric_scope.
-Notation "b 'is' 'a' 'subsequence' 'of' a" := (is_subsequence _ b a) (at level 68, only parsing) : metric_scope.
+Notation "b 'is' 'a' '_subsequence_' 'of' a" := (is_subsequence _ b a) (at level 69) : metric_scope.
+Notation "b 'is' 'a' 'subsequence' 'of' a" := (is_subsequence _ b a) (at level 69, only parsing) : metric_scope.
 Local Ltac2 unfold_is_subsequence (statement : constr) := eval unfold is_subsequence in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_subsequence (Some "subsequence") true x.
 Ltac2 Notation "_internal_" "Expand" "the" "definition" "of" "subsequence" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_subsequence (Some "subsequence") false x.
 
-Notation "p 'is' 'an' '_accumulation' 'point_' 'of' a" := (is_accumulation_point _ p a) (at level 68) : metric_scope.
-Notation "p 'is' 'an' 'accumulation' 'point' 'of' a" := (is_accumulation_point _ p a) (at level 68, only parsing) : metric_scope.
+Notation "p 'is' 'an' '_accumulation' 'point_' 'of' a" := (is_accumulation_point _ p a) (at level 69) : metric_scope.
+Notation "p 'is' 'an' 'accumulation' 'point' 'of' a" := (is_accumulation_point _ p a) (at level 69, only parsing) : metric_scope.
 Local Ltac2 unfold_is_accumulation_point (statement : constr) := eval unfold is_accumulation_point in $statement.
 Ltac2 Notation "Expand" "the" "definition" "of" "accumulation point" x(opt(seq("in", constr))) :=
   wp_unfold unfold_is_accumulation_point (Some "accumulation point") true x.

--- a/theories/Libs/Negation.v
+++ b/theories/Libs/Negation.v
@@ -21,36 +21,36 @@ Require Import Classical_Pred_Type.
 
 Lemma or_func (A B C D : Prop) :
   (A -> C) -> (B -> D) -> (A \/ B) -> (C \/ D).
-Proof. 
-  intros a_to_c b_to_d ab. 
+Proof.
+  intros a_to_c b_to_d ab.
   destruct ab as [a | b].
-  left; exact (a_to_c a). 
-  right; exact (b_to_d b). 
+  left; exact (a_to_c a).
+  right; exact (b_to_d b).
 Qed.
 
 Lemma and_func (A B C D : Prop) :
   (A -> C) -> (B -> D) -> (A /\ B) -> (C /\ D).
-Proof. 
-  intros a_to_c b_to_d ab. 
-  destruct ab as [a b]. 
+Proof.
+  intros a_to_c b_to_d ab.
+  destruct ab as [a b].
   exact (conj (a_to_c a) (b_to_d b)).
 Qed.
 
 Lemma impl_func (A B C D : Prop) :
   (C -> A) -> (B -> D) -> (A -> B) -> (C -> D).
-Proof. 
+Proof.
   intros c_to_a b_to_d a_to_b c.
   exact (b_to_d (a_to_b (c_to_a c))).
 Qed.
 
-Lemma all_func (A : Type) (P Q : A -> Prop) : 
+Lemma all_func (A : Type) (P Q : A -> Prop) :
   (forall x, P x -> Q x) -> (forall x, P x) -> (forall x, Q x).
-Proof. 
+Proof.
   intros allx_Px_to_Qx allx_Px x.
   exact ((allx_Px_to_Qx x) (allx_Px x)).
 Qed.
 
-Lemma ex_func (A : Type) (P Q : A -> Prop) : 
+Lemma ex_func (A : Type) (P Q : A -> Prop) :
   (forall x, P x -> Q x) -> (exists x, P x) -> (exists x, Q x).
 Proof.
   intros allx_Px_to_Qx somex_Px.
@@ -61,7 +61,7 @@ Qed.
 
 Lemma not_or_and_func (A B C D : Prop) :
   (~A -> C) -> (~B -> D) -> ~(A \/ B) -> (C /\ D).
-Proof. 
+Proof.
   intros na_to_c nb_to_d nab.
   tauto.
 Qed.
@@ -69,14 +69,14 @@ Qed.
 (* Reverse *)
 Lemma and_not_or_func (A B C D : Prop) :
   (C -> ~A) -> (D -> ~B) -> (C /\ D) -> ~(A \/ B).
-Proof. 
+Proof.
   intros c_to_na d_to_nb cd.
   tauto.
 Qed.
 
 Lemma not_and_or_func (A B C D : Prop) :
   (~A -> C) -> (~B -> D) -> ~(A /\ B) -> (C \/ D).
-Proof. 
+Proof.
   intros na_to_c nb_to_d nab.
   tauto.
 Qed.
@@ -84,14 +84,14 @@ Qed.
 (* Reverse *)
 Lemma or_not_and_func (A B C D : Prop) :
   (C -> ~A) -> (D -> ~B) -> (C \/ D) -> ~(A /\ B).
-Proof. 
+Proof.
   intros c_to_na d_to_nb cd.
   tauto.
 Qed.
 
 Lemma not_and_impl_func (A B C : Prop) :
   (~B -> C) -> ~(A /\ B) -> (A -> C).
-Proof. 
+Proof.
   intros nb_to_c nab.
   tauto.
 Qed.
@@ -99,7 +99,7 @@ Qed.
 (* Reverse *)
 Lemma impl_not_and_func (A B C : Prop) :
   (C -> ~B) -> (A -> C) -> ~(A /\ B).
-Proof. 
+Proof.
   intros c_to_nb a_to_c.
   tauto.
 Qed.
@@ -119,9 +119,9 @@ Proof.
   exact ((c_to_nb (proj2 ac)) (a_to_b (proj1 ac))).
 Qed.
 
-Lemma not_all_ex_func (A : Type) (P Q : A -> Prop) : 
+Lemma not_all_ex_func (A : Type) (P Q : A -> Prop) :
   (forall x, ~P x -> Q x) -> (~forall x, P x) -> (exists x, Q x).
-Proof. 
+Proof.
   intros allx_notPx_to_Qx notallx_Px.
   apply not_all_ex_not in notallx_Px.
   destruct notallx_Px.
@@ -131,9 +131,9 @@ Proof.
 Qed.
 
 (* Reverse *)
-Lemma ex_not_all_func (A : Type) (P Q : A -> Prop) : 
+Lemma ex_not_all_func (A : Type) (P Q : A -> Prop) :
   (forall x, Q x -> ~P x) -> (exists x, Q x) -> (~forall x, P x).
-Proof. 
+Proof.
   intros allx_Qx_to_notPx somex_Qx.
   apply ex_not_not_all.
   destruct somex_Qx as [x Qx].
@@ -141,9 +141,9 @@ Proof.
   exact ((allx_Qx_to_notPx x) Qx).
 Qed.
 
-Lemma not_ex_all_func (A : Type) (P Q : A -> Prop) : 
+Lemma not_ex_all_func (A : Type) (P Q : A -> Prop) :
   (forall x, ~P x -> Q x) -> (~exists x, P x) -> (forall x, Q x).
-Proof. 
+Proof.
   intros allx_notPx_to_Qx notsomex_Px.
   intuition.
   apply allx_notPx_to_Qx.
@@ -153,21 +153,21 @@ Proof.
   assumption.
 Qed.
 
-Lemma all_not_ex_func (A : Type) (P Q : A -> Prop) : 
+Lemma all_not_ex_func (A : Type) (P Q : A -> Prop) :
   (forall x, Q x -> ~P x) -> (forall x, Q x) -> (~exists x, P x).
-Proof. 
+Proof.
   intros allx_Qx_to_notPx allx_Qx.
   apply all_not_not_ex.
   intro x.
   exact ((allx_Qx_to_notPx x) (allx_Qx x)).
 Qed.
 
-Lemma not_neg_pos_func (A B : Prop) : 
+Lemma not_neg_pos_func (A B : Prop) :
   (A -> B) -> (~~A -> B).
 Proof. intros a_to_b nna. exact (a_to_b (NNPP A nna)). Qed.
 
 (* Reverse *)
-Lemma pos_not_neg_func (A B : Prop) : 
+Lemma pos_not_neg_func (A B : Prop) :
   (B -> A) -> (B -> ~~A).
 Proof.
   intros b_to_a b na.
@@ -190,7 +190,7 @@ Ltac2 solve_by_manipulating_negation_in (h_id : ident) :=
   let sort_h := get_value_of_hyp type_h in
   match check_constr_equal sort_h constr:(Prop) with
   | false => Control.zero (NegationError "Can only manipulate negation in propositions.")
-  | true => 
+  | true =>
     let attempt () :=
       revert $h_id;
       repeat (
@@ -244,7 +244,7 @@ Ltac2 solve_by_manipulating_negation_in (h_id : ident) :=
     in
     match Control.case attempt with
     | Val _ => ()
-    | Err exn => Control.zero (NegationError "Failed to solve by manipulating negation.")
+    | Err _ => Control.zero (NegationError "Failed to solve by manipulating negation.")
     end
   end.
 

--- a/theories/Tactics/Assume.v
+++ b/theories/Tactics/Assume.v
@@ -30,7 +30,7 @@ Require Import Util.TypeCorrector.
 
 Require Import Waterproof.Tactics.Help.
 
-Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) := 
+Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) :=
   concat_list [of_string "Expected assumption of "; of_constr e;
     of_string " instead of "; of_constr t; of_string "."].
 (**
@@ -46,19 +46,19 @@ Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) :=
     - If [x] contains more than one element.
 *)
 Local Ltac2 assume_negation (x : (constr * (ident option)) list) :=
-  match x with 
+  match x with
   | [] => () (* Done. *)
-  | head::tail => 
+  | head::tail =>
       match head with
       | (t, n) => (* Check whether the right negated expression is assumed. *)
           lazy_match! goal with
-          | [ |- not ?u ] => 
+          | [ |- not ?u ] =>
               let t := correct_type_by_wrapping t in
               match check_constr_equal u t with
               | false => throw (expected_of_type_instead_of_message u t)
               | true  => (* Check whether this was the only assumption made.*)
                   match tail with
-                  | h::t => throw (of_string "Nothing left to assume after the negated expression.")
+                  | _::_ => throw (of_string "Nothing left to assume after the negated expression.")
                   | [] => (* Assume negation : check whether a name has been given *)
                       match n with
                       | None   => let h := Fresh.in_goal @_H in intro $h; change $t in $h
@@ -73,12 +73,12 @@ Local Ltac2 assume_negation (x : (constr * (ident option)) list) :=
       end
   end.
 
-(**  
+(**
   Attempts to recursively assume a list of hypotheses.
 
   Arguments:
     - [x : (constr * (ident option)) list)]: list of (hypothesis and optional hypothesis name).
-  
+
   Does:
     - For the first pair of (hypothesis (and name)) in [x], assume the hypothesis (with specified name).
       If the assumed hypothesis did not come from a negated expression, proceeds to call itself with the remaining pairs in [x] as a new list [x'].
@@ -116,7 +116,7 @@ Local Ltac2 rec process_ident_type_pairs (x : (constr * (ident option)) list) :=
 
       (* Attempt to introduce remaining variables of (different) types. *)
       process_ident_type_pairs tail
-    
+
     | [] => () (* Done. *)
   end.
 
@@ -130,12 +130,12 @@ Local Ltac2 remove_contra_wrapper (wrapped_assumption : constr) (assumption : co
 (**
   Checks whether the 'Assume' tactic can be applied to the current goal, attempts to introduce a list of hypotheses.
 *)
-Local Ltac2 assume (x : (constr * (ident option)) list) := 
+Local Ltac2 assume (x : (constr * (ident option)) list) :=
   (* Handle goal wrappers *)
   lazy_match! goal with
-  | [ |- ByContradiction.Wrapper ?a _ ] => 
-      match x with 
-      | head::_ => 
+  | [ |- ByContradiction.Wrapper ?a _ ] =>
+      match x with
+      | head::_ =>
         match head with
         | (t,_) => remove_contra_wrapper a t
         end

--- a/theories/Tactics/Because.v
+++ b/theories/Tactics/Because.v
@@ -25,11 +25,11 @@ Require Import Util.Goals.
 Require Import Util.Hypothesis.
 Require Import Util.MessagesToUser.
 
-Local Ltac2 check_wrong_prop_specified (user_type:constr) (coq_type:constr) := 
+Local Ltac2 check_wrong_prop_specified (user_type:constr) (coq_type:constr) :=
  match Constr.equal user_type coq_type with
     | true  => ()
-    | false => throw (concat_list 
-      [of_string "Property "; of_constr user_type; of_string " should be "; 
+    | false => throw (concat_list
+      [of_string "Property "; of_constr user_type; of_string " should be ";
        of_constr coq_type; of_string "."])
   end.
 
@@ -67,10 +67,10 @@ Local Ltac2 and_hypothesis_destruct_with_types (s:ident) (u:ident option) (tu:co
     | Some v => v
   end
   in
-  
+
   (* Destruct copy and check if types agree. *)
   destruct $copy_val as [$uu $vv];
-  
+
   let type_u := get_value_of_hyp_id uu in
   check_wrong_prop_specified tu type_u;
 
@@ -78,7 +78,7 @@ Local Ltac2 and_hypothesis_destruct_with_types (s:ident) (u:ident option) (tu:co
   check_wrong_prop_specified tv type_v.
 
 
-Ltac2 Notation "Because" "(" s(ident) ")" "both" tu(constr) u(opt(seq("(", ident, ")"))) "and" tv(constr) v(opt(seq("(", ident, ")"))) w(opt("hold")) := 
+Ltac2 Notation "Because" "(" s(ident) ")" "both" tu(constr) u(opt(seq("(", ident, ")"))) "and" tv(constr) v(opt(seq("(", ident, ")"))) _(opt("hold")) :=
   panic_if_goal_wrapped ();
   and_hypothesis_destruct_with_types s u tu v tv.
 
@@ -95,7 +95,7 @@ Ltac2 Notation "Because" "(" s(ident) ")" "both" tu(constr) u(opt(seq("(", ident
 
   Does:
     - splits [s] into its two respective parts. Wraps the goal for both parts in the [Case.Wrapper] wrapper.
-  
+
   Raises fatal exceptions:
     - If the specified type [tu] or [tv] is not actually the type of [u] or [v] resp.
 *)
@@ -104,7 +104,7 @@ Local Ltac2 or_hypothesis_destruct_with_types (s:ident) (u:ident option) (tu:con
   let s_val := Control.hyp s in
   let copy := Fresh.in_goal @copy in
   pose $s_val as copy;
-  
+
   let copy_val := Control.hyp copy in
   (* Create identifiers if not specified. *)
   let uu := match u with
@@ -117,7 +117,7 @@ Local Ltac2 or_hypothesis_destruct_with_types (s:ident) (u:ident option) (tu:con
     | Some v => v
   end
   in
-  
+
   (* Destruct copy and check if types agree. *)
   destruct $copy_val as [$uu | $vv];
   Control.focus 1 1 (fun () =>
@@ -125,13 +125,13 @@ Local Ltac2 or_hypothesis_destruct_with_types (s:ident) (u:ident option) (tu:con
     check_wrong_prop_specified tu type_u;
     apply (Case.unwrap $type_u)
   );
-  
+
   Control.focus 2 2 (fun () =>
     let type_v := get_value_of_hyp_id vv in
     check_wrong_prop_specified tv type_v;
     apply (Case.unwrap $type_v)
   ).
 
-Ltac2 Notation "Because" "(" s(ident) ")" "either" tu(constr) u(opt(seq("(", ident, ")"))) "or" tv(constr) v(opt(seq("(", ident, ")"))) w(opt("holds")) :=
+Ltac2 Notation "Because" "(" s(ident) ")" "either" tu(constr) u(opt(seq("(", ident, ")"))) "or" tv(constr) v(opt(seq("(", ident, ")"))) _(opt("holds")) :=
   panic_if_goal_wrapped ();
   or_hypothesis_destruct_with_types s u tu v tv.

--- a/theories/Tactics/Conclusion.v
+++ b/theories/Tactics/Conclusion.v
@@ -182,7 +182,7 @@ Local Ltac2 unwrap_state_goal_no_check () :=
     - [AutomationFailure], if [waterprove] fails the prove the goal (i.e. the goal is too difficult, or does not hold).
     - [ConcludeError], if [target_goal] is not equivalent to the actual goal under focus, even after rewriting.
 *)
-Ltac2 Notation "We" "conclude" tht(opt("that")) target_goal(constr) :=
+Ltac2 Notation "We" "conclude" _(opt("that")) target_goal(constr) :=
   unwrap_state_goal_no_check ();
   panic_if_goal_wrapped ();
   guarantee_stated_goal_matches target_goal;
@@ -191,7 +191,7 @@ Ltac2 Notation "We" "conclude" tht(opt("that")) target_goal(constr) :=
 (**
   Alternative notation for [We conclude that ...].
 *)
-Ltac2 Notation "It" "follows" tht(opt("that")) target_goal(constr) :=
+Ltac2 Notation "It" "follows" _(opt("that")) target_goal(constr) :=
   unwrap_state_goal_no_check ();
   panic_if_goal_wrapped ();
   guarantee_stated_goal_matches target_goal;
@@ -208,13 +208,13 @@ Ltac2 Notation "It" "follows" tht(opt("that")) target_goal(constr) :=
     - [AutomationFailure], if [waterprove] fails the prove the goal (i.e. the goal is too difficult, or does not hold).
     - [ConcludeError], if [target_goal] is not equivalent to the actual goal under focus, even after rewriting.
 *)
-Ltac2 Notation "By" xtr_lemma(constr) "we" "conclude" tht(opt("that")) target_goal(constr) :=
+Ltac2 Notation "By" xtr_lemma(constr) "we" "conclude" _(opt("that")) target_goal(constr) :=
   unwrap_state_goal_no_check ();
   panic_if_goal_wrapped ();
   guarantee_stated_goal_matches target_goal;
   conclude_by xtr_lemma.
 
-Ltac2 Notation "Since" xtr_claim(constr) "we" "conclude" tht(opt("that")) target_goal(constr) :=
+Ltac2 Notation "Since" xtr_claim(constr) "we" "conclude" _(opt("that")) target_goal(constr) :=
   unwrap_state_goal_no_check ();
   panic_if_goal_wrapped ();
   guarantee_stated_goal_matches target_goal;
@@ -234,7 +234,7 @@ Ltac2 Notation "Since" xtr_claim(constr) "we" "conclude" tht(opt("that")) target
   Raises warning:
     - [Please come back later to provide an actual proof of [target_goal].], always.
 *)
-Ltac2 Notation "By" "magic" "we" "conclude" tht(opt("that")) target_goal(constr) :=
+Ltac2 Notation "By" "magic" "we" "conclude" _(opt("that")) target_goal(constr) :=
   unwrap_state_goal_no_check ();
   panic_if_goal_wrapped ();
   guarantee_stated_goal_matches target_goal;

--- a/theories/Tactics/Contradiction.v
+++ b/theories/Tactics/Contradiction.v
@@ -61,14 +61,14 @@ Ltac2 contra () :=
     - Throws an error if no hypohteses, or if last hypothesis cannot be negated.
 *)
 
-Ltac2 contradiction () := 
+Ltac2 contradiction () :=
   lazy_match! goal with
   | [ id_h : _ |- _ ] =>
     let h := Control.hyp id_h in
     let prop_h := get_type h in
     let id_contra := Fresh.in_goal @_Hcontra in
     lazy_match! prop_h with
-    | ~ ?p => 
+    | ~ ?p =>
       (* Try to find a proof of p *)
       match Control.case (fun () =>
         assert $p as $id_contra by
@@ -87,7 +87,7 @@ Ltac2 contradiction () :=
       match Control.case (fun () =>
         assert (~ $p) as $id_contra)
       with
-      | Err exn => throw (concat_list
+      | Err _ => throw (concat_list
         [of_string "Previous statement cannot be negated."])
       | Val _ =>
         match Control.case (fun () => Control.focus 1 1 (fun () =>
@@ -108,10 +108,10 @@ Ltac2 contradiction () :=
 
 Ltac2 Notation "We" "argue" "by" "contradiction" := contra ().
 
-Ltac2 Notation "Contradiction" := 
+Ltac2 Notation "Contradiction" :=
   panic_if_goal_wrapped ();
   contradiction ().
 
-Ltac2 Notation "↯" := 
+Ltac2 Notation "↯" :=
   panic_if_goal_wrapped ();
   contradiction ().

--- a/theories/Tactics/Either.v
+++ b/theories/Tactics/Either.v
@@ -50,10 +50,10 @@ Ltac2 either_or_prop (t1:constr) (t2:constr) :=
   let t2 := correct_type_by_wrapping t2 in
   let attempt () :=
     assert ($t1 \/ $t2) as $h_id;
-    Control.focus 1 1 (fun () => 
+    Control.focus 1 1 (fun () =>
       let automation () := waterprove 4 false Decidability in
-      first 
-        [ 
+      first
+        [
           automation ()
           | apply or_comm; automation ()
         ]
@@ -64,7 +64,7 @@ Ltac2 either_or_prop (t1:constr) (t2:constr) :=
         destruct $h_val;
         Control.focus 1 1 (fun () => apply (Case.unwrap $t1));
         Control.focus 2 2 (fun () => apply (Case.unwrap $t2))
-      | Err exn => throw (Message.of_string "Could not find a proof that the first or the second statement holds.")
+      | Err _ => throw (Message.of_string "Could not find a proof that the first or the second statement holds.")
     end.
 
 (**
@@ -81,10 +81,10 @@ Ltac2 either_or_type (t1:constr) (t2:constr) :=
   let h_id := Fresh.in_goal @_temp in
   let attempt () :=
     assert ({$t1} + {$t2}) as $h_id;
-    Control.focus 1 1 (fun () => 
+    Control.focus 1 1 (fun () =>
       let automation () := waterprove 3 false Decidability in
-      first 
-        [ 
+      first
+        [
           automation ()
           | apply sumbool_comm; automation ()
         ]
@@ -95,7 +95,7 @@ Ltac2 either_or_type (t1:constr) (t2:constr) :=
         destruct $h_val;
         Control.focus 1 1 (fun () => apply (Case.unwrap $t1));
         Control.focus 2 2 (fun () => apply (Case.unwrap $t2))
-      | Err exn => throw (Message.of_string "Could not find a proof that the first or the second statement holds.")
+      | Err _ => throw (Message.of_string "Could not find a proof that the first or the second statement holds.")
     end.
 
 (**
@@ -109,19 +109,19 @@ Ltac2 either_or_type (t1:constr) (t2:constr) :=
     - splits the proof by case distinction; wraps the resulting goals in the Case.Wrapper
 *)
 Ltac2 either_or (t1:constr) (t2:constr) :=
-  let goal_is_prop := 
+  let goal_is_prop :=
     lazy_match! goal with
-      | [ |- ?u] => 
+      | [ |- ?u] =>
         (* Check whether [u] is not a proposition. *)
         let sort_u := get_value_of_hyp(u) in
         check_constr_equal sort_u constr:(Prop)
     end
   in
-  if goal_is_prop 
+  if goal_is_prop
     then either_or_prop t1 t2
-    else either_or_type t1 t2. 
+    else either_or_type t1 t2.
 
-Ltac2 Notation "Either" t1(constr) "or" t2(constr) := 
+Ltac2 Notation "Either" t1(constr) "or" t2(constr) :=
   panic_if_goal_wrapped ();
   either_or t1 t2.
 
@@ -207,10 +207,10 @@ Ltac2 either_or_or_prop (t1:constr) (t2:constr) (t3:constr) :=
   let t3 := correct_type_by_wrapping t3 in
   let attempt () :=
     assert ($t1 \/ $t2 \/ $t3) as $h1_id;
-    Control.focus 1 1 (fun () => 
+    Control.focus 1 1 (fun () =>
       let automation () := waterprove 4 false Decidability in
-      let g := Control.goal () in first 
-      [ 
+      let _ := Control.goal () in first
+      [
         automation ()
       ]
     )
@@ -221,12 +221,12 @@ Ltac2 either_or_or_prop (t1:constr) (t2:constr) (t3:constr) :=
       let h_val := Control.hyp h1_id in
       destruct $h_val as [_ | $h2_id];
       Control.focus 1 1 (fun () => apply (Case.unwrap $t1));
-      Control.focus 2 2 (fun () => 
+      Control.focus 2 2 (fun () =>
         let h2_val := Control.hyp h2_id in
         destruct $h2_val;
         Control.focus 1 1 (fun () => apply (Case.unwrap $t2));
         Control.focus 2 2 (fun () => apply (Case.unwrap $t3)))
-    | Err exn => throw (Message.of_string "Could not find a proof that the first, the second or the third statement holds.")
+    | Err _ => throw (Message.of_string "Could not find a proof that the first, the second or the third statement holds.")
   end.
 
 (**
@@ -244,10 +244,10 @@ Ltac2 either_or_or_type (t1:constr) (t2:constr) (t3:constr) :=
   let h_id := Fresh.in_goal @_temp in
   let attempt () :=
     assert (sumtriad $t1 $t2 $t3) as $h_id;
-    Control.focus 1 1 (fun () => 
+    Control.focus 1 1 (fun () =>
       let automation () := waterprove 3 false Decidability in
-      let g := Control.goal () in first 
-      [ 
+      let _ := Control.goal () in first
+      [
         apply double_sumbool_sumtriad_abc; automation ()
       | apply double_sumbool_sumtriad_acb; automation ()
       | apply double_sumbool_sumtriad_bac; automation ()
@@ -264,7 +264,7 @@ Ltac2 either_or_or_type (t1:constr) (t2:constr) (t3:constr) :=
       Control.focus 1 1 (fun () => apply (Case.unwrap $t1));
       Control.focus 2 2 (fun () => apply (Case.unwrap $t2));
       Control.focus 3 3 (fun () => apply (Case.unwrap $t3))
-    | Err exn => throw (Message.of_string "Could not find a proof that the first, the second or the third statement holds.")
+    | Err _ => throw (Message.of_string "Could not find a proof that the first, the second or the third statement holds.")
   end.
 
 (**
@@ -280,7 +280,7 @@ Ltac2 either_or_or_type (t1:constr) (t2:constr) (t3:constr) :=
 *)
 Ltac2 either_or_or (t1:constr) (t2:constr) (t3:constr) :=
   lazy_match! goal with
-    | [ |- ?u] => 
+    | [ |- ?u] =>
       (* Check whether [u] is not a proposition. *)
       let sort_u := get_value_of_hyp(u) in
       if (check_constr_equal sort_u constr:(Prop))
@@ -288,6 +288,6 @@ Ltac2 either_or_or (t1:constr) (t2:constr) (t3:constr) :=
       else either_or_or_type t1 t2 t3
   end.
 
-Ltac2 Notation "Either" t1(constr) "," t2(constr) "or" t3(constr) := 
+Ltac2 Notation "Either" t1(constr) "," t2(constr) "or" t3(constr) :=
   panic_if_goal_wrapped ();
   either_or_or t1 t2 t3.

--- a/theories/Tactics/Help.v
+++ b/theories/Tactics/Help.v
@@ -161,7 +161,7 @@ Local Ltac2 need_to_follow_advice () : bool :=
 Local Ltac2 goal_hint () : message :=
   let gl := Control.goal () in
   lazy_match! gl with
-  | ?a -> ?b  =>
+  | ?a -> ?_b  =>
     let sort_a := get_value_of_hyp a in
     match check_constr_equal sort_a constr:(Prop) with
       | true            => goal_impl_msg a
@@ -192,7 +192,7 @@ Local Ltac2 goal_hint () : message :=
 
 Local Ltac2 forall_filter (x : constr) : bool :=
   lazy_match! x with
-  | ?a -> ?b     => false
+  | _ -> ?_b     => false
   (* | ∀ _ ∈ _, _   => true*)
   | ∀ _ _, _   => true
   | forall _, _  => true
@@ -225,13 +225,13 @@ Ltac2 print_hints () :=
       (* Then if proof can be shown automatically, suggest that, nothing else. *)
       match Control.case (solvable_by_core_auto) with
       | Val _           => print (goal_directly ())
-      | Err exn         =>
+      | Err _           =>
 
         (* Suggest hint to solve goal *)
         print (goal_hint ());
 
         (* Collect forall- and exists-statements *)
-        let hyps := List.map (fun (i, x, t) => t) (Control.hyps ()) in
+        let hyps := List.map (fun (_, _, t) => t) (Control.hyps ()) in
         let forall_hyps := List.filter (forall_filter) hyps in
         let exists_hyps := List.filter (exists_filter) hyps in
 
@@ -289,7 +289,7 @@ Ltac2 suggest_how_to_use (x : constr) (label : ident option) :=
         of_string "To use "; of_constr x; of_string ", use"]);
       print (of_string "    Obtain such a ... .") in
   lazy_match! x with
-  | ?a -> ?b => ()
+  | _ -> ?_b => ()
   | forall _, _ => print_forall_msg ()
   | ∀ _ _ , _ => print_forall_msg ()
   (* | ∀ _ > _ , _ => print_forall_msg ()
@@ -330,7 +330,7 @@ Ltac2 suggest_how_to_use_after_proof (x : constr) (label : ident option) :=
         of_string "After proving "; of_constr x; of_string ", use it with"]);
       print (of_string "    Obtain such a ... .") in
   lazy_match! x with
-  | ?a -> ?b => ()
+  | _ -> ?_b => ()
   | forall _, _ => print_forall_msg ()
   | ∀ _ _, _ => print_forall_msg ()
   (* | ∀ _ > _, _ => print_forall_msg ()

--- a/theories/Tactics/ItSuffices.v
+++ b/theories/Tactics/ItSuffices.v
@@ -77,19 +77,19 @@ Local Ltac2 wp_enough_by_admit (claim : constr) :=
     of_string " it suffices to show that ";
     of_constr claim]).
 
-Ltac2 Notation "It" "suffices" "to" "show" that(opt("that")) statement(constr) :=
+Ltac2 Notation "It" "suffices" "to" "show" _(opt("that")) statement(constr) :=
   panic_if_goal_wrapped ();
   wp_enough statement.
 
 
-Ltac2 Notation "By" xtr_lemma(constr) "it" "suffices" "to" "show" that(opt("that")) statement(constr) :=
+Ltac2 Notation "By" xtr_lemma(constr) "it" "suffices" "to" "show" _(opt("that")) statement(constr) :=
   panic_if_goal_wrapped ();
   wp_enough_by statement xtr_lemma.
 
-Ltac2 Notation "Since" xtr_claim(constr) "it" "suffices" "to" "show" that(opt("that")) statement(constr) :=
+Ltac2 Notation "Since" xtr_claim(constr) "it" "suffices" "to" "show" _(opt("that")) statement(constr) :=
   panic_if_goal_wrapped ();
   wp_enough_since statement xtr_claim.
 
-Ltac2 Notation "By" "magic" "it" "suffices" "to" "show" that(opt("that")) statement(constr) :=
+Ltac2 Notation "By" "magic" "it" "suffices" "to" "show" _(opt("that")) statement(constr) :=
   panic_if_goal_wrapped ();
   wp_enough_by_admit statement.

--- a/theories/Tactics/Obtain.v
+++ b/theories/Tactics/Obtain.v
@@ -154,14 +154,13 @@ Ltac2 obtain_seq_according_to (vars : ident list) (hyp) :=
     | _ => pre_og_type
     end in
   lazy_match! og_type with
-  | ex  ?pred => ()
-  | sig ?pred => ()
+  | ex  _ => ()
+  | sig _ => ()
   | _ => throw (concat_list
     [of_string "Can only obtain variables from 'there exists...' statements."])
   end;
   assert $pre_og_type as $prop_label;
   Control.focus 1 1 (fun () => exact $og_term);
-  let h := Control.hyp hyp in
   List.iter
     (fun var =>
       panic_ident_Qed var;
@@ -195,9 +194,9 @@ Ltac2 obtain_according_to_last (vars : ident list) :=
       | _ => pre_type_h
       end in
     lazy_match! type_h with
-    | ex  ?pred =>
+    | ex  _ =>
       obtain_seq_according_to vars id_h
-    | sig ?pred => obtain_seq_according_to vars id_h
+    | sig _ => obtain_seq_according_to vars id_h
     | _ => throw (of_string
       "Previous statement is not of the form 'there exists ...'.")
     end
@@ -205,7 +204,7 @@ Ltac2 obtain_according_to_last (vars : ident list) :=
     "No statement to obtain variable from.")
   end.
 
-Ltac2 Notation "Obtain" "such" a(opt("a")) an(opt("an"))
+Ltac2 Notation "Obtain" "such" _(opt("a")) _(opt("an"))
     vars(list1(ident, ",")) :=
   panic_if_goal_wrapped ();
   obtain_according_to_last vars.

--- a/theories/Tactics/Take.v
+++ b/theories/Tactics/Take.v
@@ -129,13 +129,13 @@ Local Ltac2 intro_with_assum (id : ident) (rhs : constr) (tk : TakeKind) :=
           of a variable of type [type], including coercions of [type].
 *)
 Local Ltac2 intro_ident (id : ident) (rhs : constr) (tk : TakeKind) :=
-  let is_sealed := lazy_match! Control.goal () with
+  let _ := lazy_match! Control.goal () with
     | seal _ _ => unfold seal at 1; true
     | _ => false
     end in
   let current_goal := Control.goal () in
   match Constr.Unsafe.kind (current_goal) with
-  | Constr.Unsafe.Prod b a =>
+  | Constr.Unsafe.Prod _ _ =>
       (* Check whether the expected binder name was provided. *)
       check_binder_warn current_goal id true
   | _ => throw (could_not_introduce_no_forall_message id)

--- a/theories/Tactics/ToShow.v
+++ b/theories/Tactics/ToShow.v
@@ -134,14 +134,11 @@ Local Ltac2 to_verify (t : constr) :=
     - To show that ...
     - To show : ...
     - To show that : ...
-
-  Optional string keywords do need to have a name, even though the parser will not populate this name.
-  (That's why it reads "that(opt('that'))" instead of "opt('that')".
 *)
-Ltac2 Notation "We" "need" "to" "show" that(opt("that")) colon(opt(":")) t(constr) := to_show t.
+Ltac2 Notation "We" "need" "to" "show" _(opt("that")) _(opt(":")) t(constr) := to_show t.
 
-Ltac2 Notation "To" "show" that(opt("that")) colon(opt(":")) t(constr) := to_show t.
+Ltac2 Notation "To" "show" _(opt("that")) _(opt(":")) t(constr) := to_show t.
 
-Ltac2 Notation "We" "need" "to" "verify" that(opt("that")) colon(opt(":")) t(constr) := to_verify t.
+Ltac2 Notation "We" "need" "to" "verify" _(opt("that")) _(opt(":")) t(constr) := to_verify t.
 
-Ltac2 Notation "To" "verify" colon(opt(":")) t(constr) := to_verify t.
+Ltac2 Notation "To" "verify" _(opt(":")) t(constr) := to_verify t.

--- a/theories/Tactics/Unfold.v
+++ b/theories/Tactics/Unfold.v
@@ -126,10 +126,10 @@ Ltac2 unfold_in_all (unfold_method: constr -> constr)
   let unfolded_goal := unfold_method goal in
   let did_unfold_goal := Bool.neg (Constr.equal unfolded_goal goal) in
 
-  let hyps := List.map (fun (i, def, t) => t) (Control.hyps ()) in
+  let hyps := List.map (fun (_, _, t) => t) (Control.hyps ()) in
   let unfolded_hyps := List.map unfold_method hyps in
   let only_unfolded_hyps :=
-    List.map (fun (uh, h) => uh) (
+    List.map (fun (uh, _) => uh) (
       List.filter_out (fun (uh, h) => Constr.equal uh h) (
         List.combine unfolded_hyps hyps
       )

--- a/theories/Util/Assertions.v
+++ b/theories/Util/Assertions.v
@@ -275,7 +275,7 @@ Ltac2 rec assert_list_equal (f : 'a -> 'a -> bool) (of_a : 'a -> message) (x:'a 
     | [] =>
       match y with
         | [] => print_success (of_string "Test passed: lists indeed equal")
-        | y_head::y_tai => fail_test (of_string "Second list has more elements")
+        | _::_ => fail_test (of_string "Second list has more elements")
       end
   end.
 

--- a/theories/Util/Binders.v
+++ b/theories/Util/Binders.v
@@ -139,8 +139,8 @@ Ltac2 change_binder_name_under_seal (c : constr) (id : ident) :=
         | _ => f
         end in
       match Constr.Unsafe.check new_f with
-      | Val x => constr:(seal $new_f $d)
-      | Err exn => c
+      | Val _ => constr:(seal $new_f $d)
+      | Err _ => c
       end
   | _ => c
   end.

--- a/theories/Waterprove.v
+++ b/theories/Waterprove.v
@@ -117,14 +117,14 @@ Local Ltac2 rec waterprove_iterate_conj (depth: int) (shield: bool)
   in
   lazy_match! goal with
   (* recursion step *)
-  | [ |- ?g1 /\ ?remainder ] =>
+  | [ |- ?g1 /\ _ ] =>
     split;
     (* Attempt to prove 1st goal *)
     match Control.case (fun () => Control.focus 1 1 (fun () =>
       _waterprove depth shield list_lemmas db_type))
     with
     | Val _ => waterprove_iterate_conj depth shield db_type xtr_lemma
-    | Err exn => Control.zero (FailedToProve g1)
+    | Err _ => Control.zero (FailedToProve g1)
     end
   (* base case *)
   | [ |- _ ] =>
@@ -133,7 +133,7 @@ Local Ltac2 rec waterprove_iterate_conj (depth: int) (shield: bool)
       _waterprove depth shield list_lemmas db_type)
     with
     | Val _ => ()
-    | Err exn => Control.zero (FailedToProve (Control.goal ()))
+    | Err _ => Control.zero (FailedToProve (Control.goal ()))
     end
   end.
 
@@ -155,7 +155,7 @@ Local Ltac2 rec rwaterprove_iterate_conj (depth: int) (shield: bool)
     | Val _ =>
       (* succesfully used lemma; prove remaining goals, but without restriction. *)
       waterprove_iterate_conj depth shield db_type (Some xtr_lemma)
-    | Err exn =>
+    | Err _ =>
       (* failed, could be due to restriction; try to prove without. *)
       match Control.case (fun () => Control.focus 1 1 (fun () =>
         _waterprove depth shield [] db_type))
@@ -163,7 +163,7 @@ Local Ltac2 rec rwaterprove_iterate_conj (depth: int) (shield: bool)
       | Val _ =>
         (* succesful. prove remaining statements with restriction. *)
         rwaterprove_iterate_conj depth shield db_type xtr_lemma
-      | Err exn => Control.zero (FailedToProve g1)
+      | Err _ => Control.zero (FailedToProve g1)
       end
     end
   (* base case *)
@@ -173,12 +173,12 @@ Local Ltac2 rec rwaterprove_iterate_conj (depth: int) (shield: bool)
       _rwaterprove depth shield db_type xtr_lemma)
     with
     | Val _ => ()
-    | Err exn => (* failed, if due to restricition, give feedback *)
+    | Err _ => (* failed, if due to restricition, give feedback *)
       (* check if it would work without lemma *)
       match Control.case (fun () =>
         _waterprove depth shield [] db_type)
       with
-      | Err exn => Control.zero (FailedToProve (Control.goal ()))
+      | Err _ => Control.zero (FailedToProve (Control.goal ()))
       | Val _ => (* problem is the extra lemma *)
         Control.zero (FailedToUse xtr_lemma)
       end
@@ -208,7 +208,7 @@ Ltac2 waterprove (depth: int) (shield: bool) (db_type: database_type) :=
       _waterprove depth shield [] db_type)
     with
     | Val _ => ()
-    | Err exn => Control.zero (FailedToProve (Control.goal ()))
+    | Err _ => Control.zero (FailedToProve (Control.goal ()))
     end
   end.
 
@@ -231,12 +231,12 @@ Ltac2 rwaterprove (depth: int) (shield: bool) (db_type: database_type) (xtr_lemm
       _rwaterprove depth shield db_type xtr_lemma)
     with
     | Val _ => ()
-    | Err exn => (* failed, if due to restricition, give feedback *)
+    | Err _ => (* failed, if due to restricition, give feedback *)
       (* check if it would work without lemma *)
       match Control.case (fun () =>
         _waterprove depth shield [] db_type)
       with
-      | Err exn => Control.zero (FailedToProve (Control.goal ()))
+      | Err _ => Control.zero (FailedToProve (Control.goal ()))
       | Val _ => (* problem is the extra lemma *)
         Control.zero (FailedToUse xtr_lemma)
       end


### PR DESCRIPTION
Warnings were fixed on branch 8.20, and the corresponding changes can be merged in coq-master. In particular:

* Unused variable warnings
* Warnings about arbitrary terms in `using` clause
* Incompatible prefix warnings