### PR TITLE
Import from Stdlib

### DIFF
--- a/tests/Notations/Sets.v
+++ b/tests/Notations/Sets.v
@@ -38,7 +38,7 @@ Abort.
 Goal ∃ x ∈ B, x = 0.
 Abort.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Open Scope R_scope.
 
 Goal ∀ x > 3, x = 5.

--- a/tests/automation/Shield.v
+++ b/tests/automation/Shield.v
@@ -18,7 +18,7 @@
 
 Require Import Ltac2.Ltac2.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/tests/automation/databases/Decidability.v
+++ b/tests/automation/databases/Decidability.v
@@ -72,7 +72,7 @@ Proof.
   auto with wp_decidability_nat.
 Qed.
 
-Require Import Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Open Scope R_scope.
 Goal forall x : R, x < 5 \/ x > 4.
 Proof.

--- a/tests/automation/databases/Integers.v
+++ b/tests/automation/databases/Integers.v
@@ -26,7 +26,7 @@ Require Import Waterproof.Tactics.
 Open Scope nat_scope.
 (* Test 0: check if notations work. *)
 
-Require Import Lia.
+From Stdlib Require Import Lia.
 
 Goal  ∀ n : ℕ -> ℕ, (∀ k : ℕ, (n (k + 1) > n k)%nat) ⇒
     ∀ k : ℕ, (n k ≥ k)%nat.
@@ -37,10 +37,9 @@ Goal  ∀ n : ℕ -> ℕ, (∀ k : ℕ, (n (k + 1) > n k)%nat) ⇒
   - assert (H1 : S k = k + 1) by (auto with wp_integers zarith).
     rewrite H1.
     assert (H2 : n (k + 1) > n k) by (auto with wp_integers zarith).
-    auto with wp_integers zarith. 
+    auto with wp_integers zarith.
 Qed.
 
-Require Import Lia.
 Goal (& 3 < 4 <= 5).
   cbn; repeat split; solve [ltac1:(auto with wp_core wp_integers)].
 Qed.

--- a/tests/automation/databases/RealsAndIntegers.v
+++ b/tests/automation/databases/RealsAndIntegers.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Require Import Ltac2.Ltac2.
 
 Require Import Waterproof.Waterproof.

--- a/tests/chains/Inequalities.v
+++ b/tests/chains/Inequalities.v
@@ -19,7 +19,7 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
@@ -101,7 +101,7 @@ Abort.
 (** Test whether one can provide a custom relation for an EqualInterpretation.
 *)
 Local Parameter X : Type.
-Require Import Relations.
+From Stdlib Require Import Relations.
 Local Parameter rel : relation X.
 
 #[local] Instance equal_setoid_interpretation : EqualInterpretation X :=

--- a/tests/chains/Manipulation.v
+++ b/tests/chains/Manipulation.v
@@ -18,8 +18,8 @@
 
 Require Import Ltac2.Ltac2.
 
-Require Import Coq.Reals.Reals.
-Require Import micromega.Lra.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
 
 Require Import Waterproof.Automation.
 Require Import Waterproof.Notations.

--- a/tests/libs/Negation.v
+++ b/tests/libs/Negation.v
@@ -17,7 +17,7 @@
 (******************************************************************************)
 
 Require Import Ltac2.Ltac2.
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
@@ -28,20 +28,20 @@ Open Scope R_scope.
 Definition Rdist (x y : R) := Rabs (x - y).
 Local Parameter (f : R -> R) (a L : R).
 
-Goal ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R, 
+Goal ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R,
           0 < Rdist x a < delta -> Rdist (f x) L < eps)
       ->
-     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R, 
+     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R,
           0 < Rdist x a < delta /\ ~ Rdist (f x) L < eps))).
 Proof.
   intro H.
   solve_by_manipulating_negation_in @H.
 Qed.
 
-Goal (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R, 
+Goal (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R,
           0 < Rdist x a < delta /\ ~ Rdist (f x) L < eps)))
      ->
-     ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R, 
+     ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R,
           0 < Rdist x a < delta -> Rdist (f x) L < eps).
 Proof.
   intro H.
@@ -203,10 +203,10 @@ Qed.
 (** Test tactic that tries every hypothesis *)
 
 (* Test 22 *)
-Goal ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R, 
+Goal ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R,
           0 < Rdist x a < delta -> Rdist (f x) L < eps)
       ->
-     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R, 
+     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R,
           0 < Rdist x a < delta /\ ~ Rdist (f x) L < eps))).
 Proof.
   intro H.
@@ -214,10 +214,10 @@ Proof.
 Qed.
 
 (* Test 23 *)
-Goal (0 = 0) -> (2 = 2) -> ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R, 
+Goal (0 = 0) -> (2 = 2) -> ~ (forall eps : R, eps > 0 -> exists delta : R, delta > 0 -> forall x : R,
           0 < Rdist x a < delta -> Rdist (f x) L < eps)
       ->
-     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R, 
+     (exists eps : R, eps > 0 /\ (forall delta : R, delta > 0 /\ (exists x : R,
           0 < Rdist x a < delta /\ ~ Rdist (f x) L < eps))).
 Proof.
   intros zero_eq_zero two_eq_two H.

--- a/tests/tactics/Choose.v
+++ b/tests/tactics/Choose.v
@@ -142,7 +142,7 @@ Proof.
   * We conclude that True.
 Qed.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Require Import Waterproof.Notations.Reals.
 Open Scope subset_scope.
 Open Scope R_scope.

--- a/tests/tactics/Conclusion.v
+++ b/tests/tactics/Conclusion.v
@@ -19,8 +19,8 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Coq.Reals.Reals.
-Require Import micromega.Lra.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/tests/tactics/Define.v
+++ b/tests/tactics/Define.v
@@ -19,7 +19,7 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/tests/tactics/Either.v
+++ b/tests/tactics/Either.v
@@ -1,7 +1,7 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
@@ -190,7 +190,7 @@ Abort.
 End test_differences_sort_of_goal.
 
 (** Test 13: Check whether we can handle boolean statements *)
-Require Import Coq.Bool.Bool.
+From Stdlib Require Import Bool.
 Goal forall b : bool, is_true(eqb b true) \/ is_true(eqb b false) -> True.
 Proof.
   intro b.
@@ -223,10 +223,10 @@ Proof.
   intro x.
   Either (x < 0) or (x ≥ 0).
   let s := Message.to_string (Message.of_constr (Control.goal ())) in
-  assert_string_equal s 
- "(Add the following line to the proof:
- 
- - Case (x < 0).)".
+  assert_string_equal s
+(String.concat "" ["(Add the following line to the proof:
+";" ";"
+ - Case (x < 0).)"]).
 Abort.
 
 Close Scope nat_scope.

--- a/tests/tactics/ItHolds.v
+++ b/tests/tactics/ItHolds.v
@@ -18,8 +18,8 @@
 
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
-Require Import Coq.Reals.Reals.
-Require Import Lra.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
 
 (* Set Default Timeout 1. *)
 

--- a/tests/tactics/Obtain.v
+++ b/tests/tactics/Obtain.v
@@ -19,14 +19,14 @@
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 
-Require Import Rbase.
-Require Import Qreals.
-Require Import Rfunctions.
-Require Import SeqSeries.
-Require Import Rtrigo.
-Require Import Ranalysis.
-Require Import Integration.
-Require Import micromega.Lra.
+From Stdlib Require Import Rbase.
+From Stdlib Require Import Qreals.
+From Stdlib Require Import Rfunctions.
+From Stdlib Require Import SeqSeries.
+From Stdlib Require Import Rtrigo.
+From Stdlib Require Import Ranalysis.
+From Stdlib Require Import Integration.
+From Stdlib Require Import Lra.
 
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.

--- a/tests/tactics/Specialize.v
+++ b/tests/tactics/Specialize.v
@@ -323,7 +323,7 @@ Qed.
 
 (** Test 23 : Choose a natural number larger than another natural number, but in R_scope. *)
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Open Scope R_scope.
 
 Goal (∀ y > 0%nat, INR(y) = 0) -> True.

--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -134,7 +134,7 @@ Goal not (0 = 1).
   Fail Take p : (0 = 1).
 Abort.
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 (** Test 13: Introducing too many variables when
     the for all statement is followed by an implication.
 *)

--- a/tests/tactics/Unfold.v
+++ b/tests/tactics/Unfold.v
@@ -198,7 +198,7 @@ Proof.
 Abort.
 
 (* Test 14: added test for a previous bug with "expand the definition in" *)
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 Require Import Waterproof.Notations.Common.
 Require Import Waterproof.Notations.Reals.
 Require Import Waterproof.Notations.Sets.

--- a/theories/Automation/Hints.v
+++ b/theories/Automation/Hints.v
@@ -18,17 +18,17 @@
 
 Require Import Ltac2.Ltac2.
 
-Require Import Arith.PeanoNat.
-Require Import Classical_Pred_Type.
-Require Import Lia.
-Require Import Lra.
-Require Import Logic.ClassicalEpsilon.
-Require Import Reals.Reals.
-Require Import Reals.Rdefinitions.
-Require Import Sets.Classical_sets.
-Require Import Sets.Ensembles.
-Require Import Notations.Sets.
+From Stdlib Require Import Arith.PeanoNat.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import Lia.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Logic.ClassicalEpsilon.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Reals.Rdefinitions.
+From Stdlib Require Import Sets.Classical_sets.
+From Stdlib Require Import Sets.Ensembles.
 
+Require Import Notations.Sets.
 Require Import Chains.
 Require Import Libs.Negation.
 Require Import Libs.Reals.

--- a/theories/Chains/Inequalities.v
+++ b/theories/Chains/Inequalities.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Reals.Rbase.
+From Stdlib Require Import Reals.Rbase.
 
 Unset Auto Template Polymorphism.
 

--- a/theories/Libs/Analysis/ContinuityDomainNat.v
+++ b/theories/Libs/Analysis/ContinuityDomainNat.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Tactics.
 Require Import Automation.

--- a/theories/Libs/Analysis/ContinuityDomainR.v
+++ b/theories/Libs/Analysis/ContinuityDomainR.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Notations.Common.
 Require Import Notations.Reals.

--- a/theories/Libs/Analysis/LimsupLiminfBolzano.v
+++ b/theories/Libs/Analysis/LimsupLiminfBolzano.v
@@ -16,10 +16,10 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Lra.
-Require Import Classical.
-Require Import Classical_Pred_Type.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
 
 Require Import Automation.
 Require Import Libs.Analysis.Sequences.

--- a/theories/Libs/Analysis/MetricSpaces.v
+++ b/theories/Libs/Analysis/MetricSpaces.v
@@ -16,9 +16,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Reals.ROrderedType.
-Require Import micromega.Lra.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Reals.ROrderedType.
+From Stdlib Require Import micromega.Lra.
 
 Require Import Tactics.
 Require Import Automation.

--- a/theories/Libs/Analysis/OpenAndClosed.v
+++ b/theories/Libs/Analysis/OpenAndClosed.v
@@ -16,8 +16,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Classical_Prop.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Classical_Prop.
 
 Require Import Automation.
 Require Import Notations.Common.

--- a/theories/Libs/Analysis/Sequences.v
+++ b/theories/Libs/Analysis/Sequences.v
@@ -16,11 +16,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Lra.
-Require Import Classical.
-Require Import Classical_Pred_Type.
-Require Import ClassicalChoice.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import ClassicalChoice.
 
 Require Import Tactics.
 Require Import Automation.

--- a/theories/Libs/Analysis/SequencesMetric.v
+++ b/theories/Libs/Analysis/SequencesMetric.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Automation.
 Require Import Libs.Negation.

--- a/theories/Libs/Analysis/SequentialAccumulationPoints.v
+++ b/theories/Libs/Analysis/SequentialAccumulationPoints.v
@@ -16,11 +16,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Lra.
-Require Import Classical.
-Require Import Classical_Pred_Type.
-Require Import ClassicalChoice.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import ClassicalChoice.
 
 Require Import Automation.
 Require Import Libs.Analysis.Sequences.

--- a/theories/Libs/Analysis/Series.v
+++ b/theories/Libs/Analysis/Series.v
@@ -16,11 +16,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Lra.
-Require Import Classical.
-Require Import Classical_Pred_Type.
-Require Import ClassicalChoice.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import ClassicalChoice.
 
 Require Import Automation.
 Require Import Libs.Analysis.Sequences.

--- a/theories/Libs/Analysis/StrongInductionIndexSequence.v
+++ b/theories/Libs/Analysis/StrongInductionIndexSequence.v
@@ -16,11 +16,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Lia.
-Require Import Arith.
-Require Import Arith.Compare.
-Require Import ClassicalChoice.
-Require Import ChoiceFacts.
+From Stdlib Require Import Lia.
+From Stdlib Require Import Arith.
+From Stdlib Require Import Arith.Compare.
+From Stdlib Require Import ClassicalChoice.
+From Stdlib Require Import ChoiceFacts.
 
 Require Export Libs.Analysis.SubsequencesMetric.
 

--- a/theories/Libs/Analysis/Subsequences.v
+++ b/theories/Libs/Analysis/Subsequences.v
@@ -16,12 +16,12 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import ZArith.
-Require Import Lra.
-Require Import Classical.
-Require Import Classical_Pred_Type.
-Require Import ClassicalChoice.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import ClassicalChoice.
 
 Require Import Automation.
 Require Import Libs.Negation.

--- a/theories/Libs/Analysis/SubsequencesMetric.v
+++ b/theories/Libs/Analysis/SubsequencesMetric.v
@@ -16,7 +16,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.ZArith.ZArith Coq.Reals.Reals.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Automation.
 Require Import Libs.Analysis.MetricSpaces.

--- a/theories/Libs/Analysis/SupAndInf.v
+++ b/theories/Libs/Analysis/SupAndInf.v
@@ -16,9 +16,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Classical.
-Require Import Classical_Pred_Type.
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Classical.
+From Stdlib Require Import Classical_Pred_Type.
+From Stdlib Require Import Reals.Reals.
 
 Require Import Tactics.
 Require Import Automation.

--- a/theories/Libs/Logic/InformativeEpsilon.v
+++ b/theories/Libs/Logic/InformativeEpsilon.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import ClassicalEpsilon.
+From Stdlib Require Import ClassicalEpsilon.
 
 (** ClassicalEpsilon allows us to lift an uninformative or to an informative or. *)
 

--- a/theories/Libs/Negation.v
+++ b/theories/Libs/Negation.v
@@ -16,8 +16,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Classical_Prop.
-Require Import Classical_Pred_Type.
+From Stdlib Require Import Classical_Prop.
+From Stdlib Require Import Classical_Pred_Type.
 
 Lemma or_func (A B C D : Prop) :
   (A -> C) -> (B -> D) -> (A \/ B) -> (C \/ D).

--- a/theories/Libs/Reals.v
+++ b/theories/Libs/Reals.v
@@ -16,9 +16,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Lra.
-Require Import Coq.Reals.Reals.
-Require Import Reals.ROrderedType.
+From Stdlib Require Import Lra.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import ROrderedType.
 
 Require Import Notations.
 

--- a/theories/Notations/Reals.v
+++ b/theories/Notations/Reals.v
@@ -16,8 +16,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Coq.Reals.Reals.
-Require Import Qreals.
+From Stdlib Require Import Reals.Reals.
+From Stdlib Require Import Qreals.
 
 Require Import Notations.Common.
 Require Import Notations.Sets.

--- a/theories/Notations/Sets.v
+++ b/theories/Notations/Sets.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Sets.Ensembles.
+From Stdlib Require Import Sets.Ensembles.
 
 Require Import Notations.Common.
 
@@ -78,7 +78,7 @@ Definition seal {T : Type} (Q : T -> Prop) (y : T) := Q y.
 
 
 
-Require Import Coq.Reals.Reals.
+From Stdlib Require Import Reals.Reals.
 
 Class ge_type (carrier : Type) := {
   ge_op : carrier -> carrier -> Prop

--- a/theories/Tactics/Contradiction.v
+++ b/theories/Tactics/Contradiction.v
@@ -16,7 +16,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Classical.
+From Stdlib Require Import Classical.
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 Local Ltac2 concat_list (ls : message list) : message :=


### PR DESCRIPTION
We no longer implicitly import from `Stdlib` or `Coq`, but explicitly do so, in line with the deprecation warnings. This basically does the same as #79 but in more places in the library, and uses the `Stdlib` import rather than the `Coq` import.