### PR TITLE
Backport changes for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ META
 *.css
 *.diags
 *.install
+
+waterproof-exercises

--- a/Developer-instructions.md
+++ b/Developer-instructions.md
@@ -119,8 +119,8 @@ dune build -p coq-waterproof
 
 ## Running external tests
 
-If one has a folder `waterproof-exercises` at the same level as the folder
-`coq-waterproof`, one can test coq-waterproof against all the files
+If one has symlink to a folder called `waterproof-exercises` 
+in the project root (i.e. in `coq-waterproof`), one can test coq-waterproof against all the files
 (typically exercise sheets) in `waterproof-exercises` by executing
 
 ```

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,7 @@
-(lang dune 3.6)
-(using coq 0.6)
+(lang dune 3.8)
+(using coq 0.8)
+(using directory-targets 0.1)
+
 
 (package
  (name coq-waterproof)

--- a/tests/test-folder.py
+++ b/tests/test-folder.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         raise Exception(f"Could not find the folder {FOLDER}")
     for filename in glob.iglob('**/*.mv', recursive=True, root_dir=FOLDER):
         print(filename)
-        result = subprocess.run(['fcc', '--root=../../../', f'{FOLDER}/{filename}'],
+        result = subprocess.run(['fcc', f'{FOLDER}/{filename}'],
                        capture_output=True)
         if result.returncode != 0:
             raise Exception(f"Compilation of file {filename} has failed\n{result.stderr}")

--- a/tests/test-folder.py
+++ b/tests/test-folder.py
@@ -21,6 +21,11 @@ if __name__ == "__main__":
     failed = False
     print("Current working directory:")
     print(os.getcwd())
+    print("fcc version:")
+    result = subprocess.run(['which', 'fcc'], capture_output=True)
+    print(result.stdout)
+    if not os.path.isdir(FOLDER):
+        raise Exception(f"Could not find the folder {FOLDER}")
     for filename in glob.iglob('**/*.mv', recursive=True, root_dir=FOLDER):
         print(filename)
         result = subprocess.run(['fcc', '--root=../../../', f'{FOLDER}/{filename}'],

--- a/theories/dune
+++ b/theories/dune
@@ -2,15 +2,24 @@
   (name Waterproof)
   (package coq-waterproof)
   (flags :standard)
+  (theories Ltac2)
   (plugins coq-waterproof.plugin coq-core.plugins.ltac coq-core.plugins.ltac2))
+
+; For later versionos of Coq, this should be:
+; (theories Stdlib Ltac2)
+; (plugins coq-waterproof.plugin rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2)
 
 (include_subdirs qualified)
 
 (rule
  (alias runtest)
- (deps (alias ../install))
+ (deps
+  (package coq-waterproof)
+  (package coq-lsp)
+  %{project_root}/tests/test-folder.py
+  (source_tree %{workspace_root}/waterproof-exercises))
  (action (progn
              (echo "Testing:")
              (run pwd)
-             (run python3 ../../../tests/test-folder.py ../../../../waterproof-exercises)
+             (run python3 %{project_root}/tests/test-folder.py %{workspace_root}/../../waterproof-exercises/Analysis-1)
 )))


### PR DESCRIPTION
Improve the testing setup: Let dune look for the correct dependencies of the tests, and work with variable names for the workspace and project roots. It also bumps the dune version, and adds Ltac2 as a dependency.

For this to work, one should create a symlink to waterproof-exercises in the coq-waterproof directory.