### PR TITLE
Fix the root for fcc in the test script

### DIFF
--- a/tests/test-folder.py
+++ b/tests/test-folder.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         raise Exception(f"Could not find the folder {FOLDER}")
     for filename in glob.iglob('**/*.mv', recursive=True, root_dir=FOLDER):
         print(filename)
-        result = subprocess.run(['fcc', f'{FOLDER}/{filename}'],
+        result = subprocess.run(['fcc', '--root=../../../', f'{FOLDER}/{filename}'],
                        capture_output=True)
         if result.returncode != 0:
             raise Exception(f"Compilation of file {filename} has failed\n{result.stderr}")


### PR DESCRIPTION
In the previous version, the fcc script was using the installed coq-waterproof version, not the one that was just being built. This should be fixed now by changing the root of the script.