### PR TITLE
Add Coq as a dependency (which seems necessary for a dune build)

### DIFF
--- a/coq-waterproof.opam
+++ b/coq-waterproof.opam
@@ -26,6 +26,7 @@ bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
 depends: [
   "ocaml" {>= "4.09.0"}
   "rocq-prover" {>= "9.0" & < "9.1" | = "dev"}
+  "coq" {>= "9.0" & < "9.1" | = "dev"}
   "dune" {>= "3.8"}
 ]
 


### PR DESCRIPTION
We add coq back as a dependency in the `coq-waterproof.opam` file, because this seems necessary for a dune build