### PR TITLE
Filter errors to explain errors a bit more

### DIFF
--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -17,6 +17,11 @@
 (******************************************************************************)
 
 (**
+  A flag that determines whether Waterproof should filter errors
+*)
+val filter_errors : bool ref
+
+(**
   A rudimentary feedback log
 *)
 val feedback_log : Feedback.level -> Pp.t list ref
@@ -74,7 +79,7 @@ type wexn =
 *)
 val throw : ?info:Exninfo.info -> wexn -> 'a
 
-(** 
+(**
   Sends a warning
 *)
 val warn :

--- a/src/g_waterproof.mlg
+++ b/src/g_waterproof.mlg
@@ -39,6 +39,20 @@ VERNAC COMMAND EXTEND AutomationShieldDisableSideEff CLASSIFIED AS SIDEFF
     }
 END
 
+VERNAC COMMAND EXTEND FilterErrorsEnableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Enable" "Filter" "Errors" ] ->
+    {
+      filter_errors := true
+    }
+END
+
+VERNAC COMMAND EXTEND FilterErrorsDisableSideEff CLASSIFIED AS SIDEFF
+  | [ "Waterproof" "Disable" "Filter" "Errors" ] ->
+    {
+      filter_errors := false
+    }
+END
+
 VERNAC COMMAND EXTEND AutomationDebugEnableSideEff CLASSIFIED AS SIDEFF
   | [ "Waterproof" "Enable" "Debug" "Automation" ] ->
     {


### PR DESCRIPTION
Adds an error handler so the error messages that are being sent on Rocq errors can be slightly reformulated. These Rocq errors just fly through and we cannot catch them in Ltac2.

**Testing this pull request:**

I do not see a way to add automated tests for this addition at the moment. Testing should be done manually, by opening the tutorial and creating a syntax error, and by checking the tutorial at example 10, and changing `* Indeed, (1 / 2 > 0).` to `Indeed, (1 / 2 > 0).`.