### PR TITLE
[build] Add more paths to CoqProject to support vendored build

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,7 +1,10 @@
 # This _CoqProject file is intended for use with the coq-lsp library
+# We do a little hack to support two different build layouts
+-arg -w -arg -cannot-open-path
 src/META.coq-waterproof
 -R theories/ Waterproof
 -R _build/default/theories/ Waterproof
--I _build/install/default/lib/coq-waterproof/plugin
--I _build/install/default/lib/
+-R ../_build/default/coq-waterproof/theories/ Waterproof
+-I ../_build/install/default/lib/coq-waterproof/plugin
+-I ../_build/install/default/lib/
 -I src


### PR DESCRIPTION
This is a bit hacky, but makes coq-waterproof work fine in both vendored and non-vendored build setups.

Note: you need to bump the submodule in waterproof-dev