### PR TITLE
Natural formulation for assuming multiple premises at once

### DIFF
--- a/tests/tactics/Assume.v
+++ b/tests/tactics/Assume.v
@@ -82,7 +82,7 @@ Abort.
 *)
 Goal forall A B C D E F G: Prop, (A /\ B) -> (B /\ C) -> (C /\ D) -> (D /\ E) -> (E /\ F) -> (F /\ G).
   intros A B C D E F G.
-  Assume that (A /\ B) (i), (B /\ C), (C /\ D), (D /\ E) (ii) and (E /\ F).
+  Assume that A /\ B as (i), B /\ C, C /\ D, D /\ E as (ii) and E /\ F.
   assert_hyp_has_type @i '(A /\ B).
   assert_hyp_has_type @ii '(D /\ E).
 Abort.

--- a/tests/tactics/Assume.v
+++ b/tests/tactics/Assume.v
@@ -78,27 +78,36 @@ Goal forall A B C: Prop, (A /\ B) -> (B /\ C) -> (A /\ C).
     assert_hyp_has_type @i constr:(B /\ C).
 Abort.
 
-(** * Test 8: assume too many hypotheses.
+(** * Test 8: multiple hypotheses, assume separately using a single tactic.
+*)
+Goal forall A B C D E F G: Prop, (A /\ B) -> (B /\ C) -> (C /\ D) -> (D /\ E) -> (E /\ F) -> (F /\ G).
+  intros A B C D E F G.
+  Assume that (A /\ B) (i), (B /\ C), (C /\ D), (D /\ E) (ii) and (E /\ F).
+  assert_hyp_has_type @i '(A /\ B).
+  assert_hyp_has_type @ii '(D /\ E).
+Abort.
+
+(** * Test 9: assume too many hypotheses.
 *)
 Goal forall A B C: Prop, (A /\ B) -> (A /\ C).
     intros A B C.
     Fail Assume that A /\ B and B /\ C.
 Abort.
 
-(** * Test 9: assume wrong hypothesis.
+(** * Test 10: assume wrong hypothesis.
 *)
 Goal forall A B C: Prop, (A /\ B) -> (A /\ C).
     intros A B C.
     Fail Assume that A /\ C.
 Abort.
 
-(** * Test 10: assume when there is nothing to assume.)
+(** * Test 11: assume when there is nothing to assume.)
 *)
 Goal exists n, n > 0.
   Fail Assume that 0 = 0 as (i).
 Abort.
 
-(** * Test 11: assume a negated expression.)
+(** * Test 12: assume a negated expression.)
 *)
 Goal forall P : Prop, not (not (not P)) -> not P.
   intro P.
@@ -106,7 +115,7 @@ Goal forall P : Prop, not (not (not P)) -> not P.
   Assume that P.
 Abort.
 
-(** * Test 12: assume the wrong negated expression.)
+(** * Test 13: assume the wrong negated expression.)
 *)
 Goal forall P : Prop, not (not (not P)) -> not P.
   intro P.
@@ -114,7 +123,7 @@ Goal forall P : Prop, not (not (not P)) -> not P.
   Fail Assume that (not P).
 Abort.
 
-(** * Test 13: assume something after negated expression.)
+(** * Test 14: assume something after negated expression.)
 *)
 Goal forall P : Prop, not (not (not P)) -> not P.
   intro P.
@@ -122,20 +131,20 @@ Goal forall P : Prop, not (not (not P)) -> not P.
   Fail Assume that P and 0 = 0.
 Abort.
 
-(** * Test 14: assume something and negated expression in one go.)
+(** * Test 15: assume something and negated expression in one go.)
 *)
 Goal forall P : Prop, not (not (not P)) -> not P.
   intro P.
   Assume that not (not (not P)) and P.
 Abort.
 
-(** * Test 15: should reject trying to construct a map.
+(** * Test 16: should reject trying to construct a map.
 *)
 Goal nat -> nat.
   Fail Assume that nat (n).
 Abort.
 
-(** * Test 16: should reject trying to construct a map.
+(** * Test 17: should reject trying to construct a map.
 *)
 Goal (0 = 0) -> nat -> nat.
   Fail Assume that 0 = 0 and nat.
@@ -143,7 +152,7 @@ Goal (0 = 0) -> nat -> nat.
   Fail Assume that nat.
 Abort.
 
-(** * Test 17: should correctly handle boolean goal
+(** * Test 18: should correctly handle boolean goal
 *)
 Goal is_true true -> (0 = 0).
 Proof.

--- a/tests/tactics/TakeSuchThat.v
+++ b/tests/tactics/TakeSuchThat.v
@@ -50,7 +50,7 @@ Abort.
 *)
 Goal forall A B C: Prop, (A /\ B) /\ (B /\ C) -> (A /\ C).
     intros A B C.
-    Fail such that A and B and B /\ C.
+    Fail such that A, B and B /\ C.
     (*assert_hyp_has_type @a constr:(A).
     assert_hyp_has_type @b constr:(B).
     assert_hyp_has_type @bc constr:(B /\ C).*)

--- a/theories/Tactics/Assume.v
+++ b/theories/Tactics/Assume.v
@@ -173,21 +173,17 @@ Local Ltac2 parse_natural_language_listing (x1 : constr * (ident option))
 (**
   Version with type checking.
 *)
-Ltac2 Notation "Assume" "that" x1(seq(lconstr, opt(seq("(", ident, ")")))) 
-  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("(", ident, ")"))), ",")))),
-  "and", seq(lconstr, opt(seq("(", ident, ")"))))) )
+Ltac2 Notation "Assume" "that" x1(seq(lconstr, opt(seq("as", "(", ident, ")")))) 
+  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("as", "(", ident, ")"))), ",")))),
+  "and", seq(lconstr, opt(seq("as", "(", ident, ")"))))) )
 := assume (parse_natural_language_listing x1 x2).
 
-(* Goal forall n, n = 1 /\ n = 2 -> False.
-  intros n.
-  Assume that (n = 1 /\ n = 2) (i), (1=10) (j), (2=2) and (0=0) (star).
-Abort.   *)
 
 
 (**
   Simply alternative notation for [Assume].
 *)
-Ltac2 Notation "such" "that" x1(seq(lconstr, opt(seq("(", ident, ")")))) 
-  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("(", ident, ")"))), ",")))),
-  "and", seq(lconstr, opt(seq("(", ident, ")"))))) )
+Ltac2 Notation "such" "that" x1(seq(lconstr, opt(seq("as", "(", ident, ")")))) 
+  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("as", "(", ident, ")"))), ",")))),
+  "and", seq(lconstr, opt(seq("as", "(", ident, ")"))))) )
 := assume (parse_natural_language_listing x1 x2).

--- a/theories/Tactics/Assume.v
+++ b/theories/Tactics/Assume.v
@@ -154,12 +154,40 @@ Local Ltac2 assume (x : (constr * (ident option)) list) :=
 Notation "[ ( % @ < x 'and'" := x (at level 0, only parsing).
 Notation "[ ( % @ < x 'as'" := x (at level 0, only parsing).
 
+
+(**
+  Parses input from Ltac2 notation of the form 'A (i), B, C, D (ii), E and F', 
+  see tactic notation specifications below.
+  Returns a single list with the user's input (e.g. the above becomes [A (i); B; C; D (ii); E; F]).
+*)
+Local Ltac2 parse_natural_language_listing (x1 : constr * (ident option)) 
+  (x2 : ((((constr * (ident option)) list) option) * (constr * (ident option))) option) 
+  : (constr * (ident option)) list :=
+  match x2 with 
+  | Some (Some x2, x3)  => List.append (x1 :: x2) [x3]
+  | Some (None   , x3)  => [x1; x3]
+  | None                => [x1]
+  end.
+
+
 (**
   Version with type checking.
 *)
-Ltac2 Notation "Assume" "that" x(list1(seq(lconstr, opt(seq("as", "(", ident, ")"))), "and")) := assume x.
+Ltac2 Notation "Assume" "that" x1(seq(lconstr, opt(seq("(", ident, ")")))) 
+  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("(", ident, ")"))), ",")))),
+  "and", seq(lconstr, opt(seq("(", ident, ")"))))) )
+:= assume (parse_natural_language_listing x1 x2).
+
+(* Goal forall n, n = 1 /\ n = 2 -> False.
+  intros n.
+  Assume that (n = 1 /\ n = 2) (i), (1=10) (j), (2=2) and (0=0) (star).
+Abort.   *)
+
 
 (**
   Simply alternative notation for [Assume].
 *)
-Ltac2 Notation "such" "that" x(list1(seq(lconstr, opt(seq("as", "(", ident, ")"))), "and")) := assume x.
+Ltac2 Notation "such" "that" x1(seq(lconstr, opt(seq("(", ident, ")")))) 
+  x2(opt(seq(opt(seq(",", seq(list0(seq(lconstr, opt(seq("(", ident, ")"))), ",")))),
+  "and", seq(lconstr, opt(seq("(", ident, ")"))))) )
+:= assume (parse_natural_language_listing x1 x2).


### PR DESCRIPTION
Example old syntax:
```
Assume that A /\ B as (i) and B /\ C and C /\ D and D /\ E as (ii) and E /\ F.
```

Example new syntax:
```
Assume that A /\ B as (i), B /\ C, C /\ D, D /\ E as (ii) and E /\ F.
```

Decided to **not** use the Oxford comma, but this can be changed easily.