### PR TITLE
Small update 'By/Since ... it holds that' tactic

### DIFF
--- a/_CoqProjectForMake
+++ b/_CoqProjectForMake
@@ -78,7 +78,7 @@ theories/Util/Evars.v
 theories/Util/Goals.v
 theories/Util/Hypothesis.v
 theories/Util/Init.v
-theories/Util/Since.v
+theories/Util/BySince.v
 theories/Util/MessagesToUser.v
 theories/Util/TypeCorrector.v
 

--- a/tests/tactics/ItHolds.v
+++ b/tests/tactics/ItHolds.v
@@ -255,12 +255,18 @@ Proof.
   Since A -> B it holds that B.
 Abort.
 
+Waterproof Enable Redirect Errors.
+
 (* Test 16: 'Since ...' with reference fails. *)
 Goal A -> False.
 Proof.
   intro H.
-  Fail Since f it holds that B.
+  assert_fails_with_string (fun () => Since f it holds that B)
+  "Cannot use reference f with `Since`.
+Try `By f ...` instead.".
 Abort.
+
+Waterproof Disable Redirect Errors.
 
 
 (** Tests for workaround occuring anomalies in [_rwaterprove]. *)

--- a/theories/Tactics/Conclusion.v
+++ b/theories/Tactics/Conclusion.v
@@ -23,7 +23,7 @@ Require Import Notations.Sets.
 Require Import Chains.Inequalities.
 Require Import Util.Goals.
 Require Import Util.Init.
-Require Import Util.Since.
+Require Import Util.BySince.
 Require Import Waterprove.
 Require Import MessagesToUser.
 Require Import Util.TypeCorrector.

--- a/theories/Tactics/ItHolds.v
+++ b/theories/Tactics/ItHolds.v
@@ -25,7 +25,7 @@ Require Import Util.Constr.
 Require Import Util.Goals.
 Require Import Util.Hypothesis.
 Require Import Util.Init.
-Require Import Util.Since.
+Require Import Util.BySince.
 Require Import Util.MessagesToUser.
 Require Import Util.TypeCorrector.
 Require Import Waterprove.

--- a/theories/Tactics/ItSuffices.v
+++ b/theories/Tactics/ItSuffices.v
@@ -21,7 +21,7 @@ Require Import Ltac2.Message.
 
 Require Import Util.Init.
 Require Import Util.Goals.
-Require Import Util.Since.
+Require Import Util.BySince.
 Require Import Util.MessagesToUser.
 Require Import Util.TypeCorrector.
 Require Import Waterprove.

--- a/theories/Util/BySince.v
+++ b/theories/Util/BySince.v
@@ -42,6 +42,7 @@ Local Ltac2 check_if_not_reference (x : constr) :=
   | Prop => ()
   | Set => ()
   | Type => ()
+  | bool => ()
   | _ => throw (concat_list
         [of_string "Cannot use reference "; of_constr x; of_string " with `Since`.
 Try `By "; of_constr x; of_string " ...` instead."])
@@ -57,6 +58,7 @@ Try `Since "; of_constr x; of_string " ...` instead."]
   | Prop => throw err_msg
   | Set => throw err_msg
   | Type => throw err_msg
+  | bool => throw err_msg
   | _ => ()
   end.
 
@@ -70,10 +72,10 @@ Try `Since "; of_constr x; of_string " ...` instead."]
 *)
 
 Ltac2 since_framework (by_tactic : constr -> unit) (claimed_cause : constr) :=
-  (* Wrap in is_true if needed *)
-  let claimed_cause := correct_type_by_wrapping claimed_cause in
   (* first, check if [claimed_cause] is a statement. *)
   check_if_not_reference claimed_cause;
+  (* Wrap in is_true if needed *)
+  let claimed_cause := correct_type_by_wrapping claimed_cause in
 
   let id_cause := Fresh.in_goal @_temp in
   (* attempt to prove [claimed_cause]*)

--- a/theories/Util/BySince.v
+++ b/theories/Util/BySince.v
@@ -16,6 +16,13 @@
 (*                                                                            *)
 (******************************************************************************)
 
+
+(**
+Shared code for the 'Since ...' and 'By ...' prefix clauses for tactics like 'It holds that ...' or 'We conclude that ...'
+*)
+
+
+
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Message.
 Local Ltac2 concat_list (ls : message list) : message :=

--- a/theories/Util/BySince.v
+++ b/theories/Util/BySince.v
@@ -38,7 +38,7 @@ Require Import Notations.Sets.
 
 Local Ltac2 check_if_not_reference (x : constr) :=
   let type_x := Constr.type x in
-  match! type_x with
+  lazy_match! type_x with
   | Prop => ()
   | Set => ()
   | Type => ()
@@ -54,7 +54,7 @@ Local Ltac2 check_if_not_statement (x : constr) :=
 Try `Since "; of_constr x; of_string " ...` instead."]
   in
   let type_x := Constr.type x in
-  match! type_x with
+  lazy_match! type_x with
   | Prop => throw err_msg
   | Set => throw err_msg
   | Type => throw err_msg

--- a/theories/Util/TypeCorrector.v
+++ b/theories/Util/TypeCorrector.v
@@ -27,7 +27,7 @@ Local Ltac2 concat_list (ls : message list) : message :=
 (** Ensures that the type of [t] can be used in type matching or asserting. *)
 Ltac2 correct_type_by_wrapping (t: constr): constr :=
   let type_t := Constr.type t in
-  match! type_t with
+  lazy_match! type_t with
     | Prop => t
     | Set => t 
     | Type => t


### PR DESCRIPTION
- Renamed corresponding utilities file.
- Fixes in error messages
  - Correct output when extra lemma had to be unsealed
  - Suggestion to use By resp. Since in case of boolean input
- Added test case using assertion framework. This required reworking some of the control flow since the tactic gave different errors depending on whether redirecting of errors was enabled or disabled. The old control flow assumed that errors thrown with Waterproof's `throw`-function would be non-catchable.