### PR TITLE
Modify _CoqProject file for use with coq-lsp

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,8 @@
 src/META.coq-waterproof
 -R theories/ Waterproof
 -R _build/default/theories/ Waterproof
+-I _build/install/default/lib/coq-waterproof/plugin
+-I _build/install/default/lib/
 -R ../_build/default/coq-waterproof/theories/ Waterproof
 -I ../_build/install/default/lib/coq-waterproof/plugin
 -I ../_build/install/default/lib/


### PR DESCRIPTION
The new _CoqProject file did not work when developing directly in the coq-waterproof folder.