### PR TITLE
Improve error messages for Take tactic

### DIFF
--- a/tests/tactics/Take.v
+++ b/tests/tactics/Take.v
@@ -311,7 +311,8 @@ Waterproof Enable Redirect Errors.
 (** Test 32, Use take with the wrong symbol *)
 Goal ∀ n > 3, n = 0.
 assert_fails_with_string (fun () => Take n < 3)
-"The condition (n < 3) does not correspond to the expected condition (n > 3)".
+(String.concat "" ["The provided condition (n < 3) does not correspond to the expected condition in the for-all statement"; "
+"; "(n > 3)"]).
 Abort.
 
 (** Test 33, Check that subset type is simplified when using Take with colon *)
@@ -343,3 +344,45 @@ Goal ∀ m ∈ nat, ∀ n ∈ nat, ∀ k ∈ nat, ∀ l ∈ nat, ∀ j ∈ nat, 
 Proof.
 Take m, n ∈ const_nat 0 and k, l ∈ const_nat 1 and j ∈ const_nat 2.
 Abort.
+
+Open Scope R_scope.
+
+(** Test 36, Check error message, when providing ∈ condition, while > is expected *)
+
+Goal ∀ m > 0, True.
+Proof.
+assert_fails_with_string (fun () => Take m ∈ R)
+   (String.concat "" ["The provided condition m ∈ ℝ does not correspond to the expected condition in the for-all statement "; "
+"; "(m >"; " 0)"]).
+Abort.
+
+(** Test 37, Check error message, when providing > condition, while ∈ is expected *)
+
+Goal ∀ m ∈ ℝ, True.
+Proof.
+assert_fails_with_string (fun () => Take m > 0)
+  (String.concat "" ["The provided condition (m > 0) does not correspond to the expected condition in the for-all statement";"
+"; "(m ∈ ℝ)"]).
+Abort.
+
+(** Test 38, Check error message, when using ∈ rather than :, and provided space is incorrect *)
+
+Goal ∀ f : ℝ -> ℝ, True.
+Proof.
+assert_fails_with_string (fun () => Take f ∈ (ℝ -> ℝ))
+  (String.concat "" ["The provided condition f ∈ (ℝ -> ℝ) does not correspond to the expected condition in the for-all statement f : "; "
+"; "(ℝ -> ℝ)"]
+  ).
+Abort.
+
+(** Test 39, Check error message, when using ∈ rather than :, and provided space is incorrect *)
+
+Goal ∀ f : ℝ -> ℝ, True.
+Proof.
+assert_fails_with_string (fun () => Take f ∈ (ℝ))
+  (String.concat "" ["The provided condition f ∈ ℝ does not correspond to the expected condition in the for-all statement f : "; "
+"; "(ℝ -> ℝ)"]
+  ).
+Abort.
+
+Close Scope R_scope.

--- a/theories/Tactics/Take.v
+++ b/theories/Tactics/Take.v
@@ -47,7 +47,22 @@ Local Ltac2 expected_of_type_instead_of_message (e : constr) (t : constr) :=
     of_string " instead of "; of_constr t; of_string "."].
 
 Local Ltac2 expected_different_condition_message (e : constr) (expected : constr) :=
-  concat_list [of_string "The condition " ; of_constr e; of_string " does not correspond to the expected condition "; of_constr expected].
+  let simplified_e := (eval cbn in $e) in
+  concat_list [of_string "The provided condition " ; of_constr simplified_e;
+  of_string " does not correspond to the expected condition in the for-all statement"; of_constr expected].
+
+Local Ltac2 expected_el_message (e : constr) (z : ident) (expected_rhs : constr) :=
+  let simplified_e := (eval cbn in $e) in
+  concat_list [of_string "The provided condition " ;
+  of_ident z; of_string " ∈ "; of_constr expected_rhs;
+  of_string " does not correspond to the expected ";
+  of_string "condition in the for-all statement "; of_constr simplified_e ].
+
+Local Ltac2 expected_col_not_el_message (z : ident) (provided_rhs : constr)
+  (expected_rhs : constr) :=
+  concat_list [of_string "The provided condition " ; of_ident z; of_string " ∈ ";
+  of_constr provided_rhs; of_string " does not correspond to the expected condition in the for-all statement ";
+  of_ident z; of_string " : "; of_constr expected_rhs ].
 
 Ltac2 Type TakeKind :=
   [TakeCol | TakeEl | TakeGt | TakeGe | TakeLt | TakeLe | TakeNone ].
@@ -103,7 +118,7 @@ Local Ltac2 intro_with_assum (id : ident) (rhs : constr) (tk : TakeKind) :=
   let id_c := Control.hyp id in
   let pred := pred_from_take_kind rhs tk in
   lazy_match! (Control.goal ()) with
-  | (?cond -> _) => (* FIXME: this check should be more strict *)
+  | (?cond -> _) =>
     if check_constr_equal constr:($pred $id_c) cond then
       let w := Fresh.fresh (Fresh.Free.of_goal ()) @_H in
       intro $w;
@@ -142,7 +157,8 @@ Local Ltac2 intro_ident (id : ident) (rhs : constr) (tk : TakeKind) :=
   | _ => throw (could_not_introduce_no_forall_message id)
   end;
   match tk with
-  | TakeCol =>
+  | (* User uses Take ... : ... notation *)
+    TakeCol =>
     let type := rhs in
     lazy_match! (Control.goal ()) with
       | (forall _ : ?u, _) =>
@@ -152,7 +168,10 @@ Local Ltac2 intro_ident (id : ident) (rhs : constr) (tk : TakeKind) :=
         else throw (too_many_of_type_message type)
       | _ => throw (could_not_introduce_no_forall_message id)
       end
-  | TakeEl =>
+  | (* User uses Take ... ∈ ... notation. This requires separate
+       treatment due to the difficulties with coercions with the
+       sets on the right-hand side. *)
+    TakeEl =>
     let type := rhs in
     intro $id;
     unfold subset_type in $id;
@@ -177,9 +196,13 @@ Local Ltac2 intro_ident (id : ident) (rhs : constr) (tk : TakeKind) :=
       else
         throw (expected_different_condition_message constr:($v ∈ $set_in_cond)
           constr:($id_c ∈ $rhs))
-    | _ => throw (expected_implication_message id)
+    | (?v -> _) =>
+        throw (expected_el_message constr:($v) id rhs)
+    | _ =>
+      throw (expected_col_not_el_message id rhs (Constr.type id_c))
     end
-  | _ => intro_with_assum id rhs tk
+  | (* User uses one of the other notations: separate function *)
+    _ => intro_with_assum id rhs tk
   end.
 
 (**

--- a/theories/Util/Assertions.v
+++ b/theories/Util/Assertions.v
@@ -107,7 +107,7 @@ Ltac2 assert_fails_with_string (tac : unit -> 'a) (expected_string : string) :=
         print_success (of_string ("The tactic failed with the expected error message"))
       else
         fail_test (concat_list [of_string "The tactic failed, but with an unexpected error message. Expected:"; fnl ();
-        of_string expected_string; fnl (); of_string "Got:"; fnl (); msg]) in
+        of_string expected_string; fnl (); of_string "Got:"; fnl (); of_string (Message.to_string msg)]) in
     match exn with
     | RedirectedToUserError msg => inner_msg_test msg
     | TestFailedError msg => inner_msg_test msg


### PR DESCRIPTION
Improves error messages on `Take`, and in particular fixes #134

For impression of improvement, see the new tests in `tests/tactics/Take.v`.