### PR TITLE
Allow preconfigured failures

### DIFF
--- a/tests/test-folder.py
+++ b/tests/test-folder.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
                     msg = diag.get('message')
 
                     # if exact message is listed, skip it and remove it to show we processed it.
-                    if len(exceptions) > 0 and msg.strip() == exceptions[0]:
+                    if len(exceptions) > 0 and msg.strip() in exceptions[0]:
                         exceptions.pop(0)
                         continue
 

--- a/tests/test-folder.py
+++ b/tests/test-folder.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
                     msg = diag.get('message')
 
                     # if exact message is listed, skip it and remove it to show we processed it.
-                    if len(exceptions) > 0 and msg.strip() in exceptions[0]:
+                    if len(exceptions) > 0 and exceptions[0] in msg.strip():
                         exceptions.pop(0)
                         continue
 


### PR DESCRIPTION
This will allow us to mark expected failures of tests using a file with the same name as the .mv-file except ending in .test instead. This file contains a list of expected messages in order, for which the corresponding diagnostics are then not considered failures for purposes of testing.