### PR TITLE
Update ffi mechanism, after simplication in Coq 8.19

### DIFF
--- a/Developer-instructions.md
+++ b/Developer-instructions.md
@@ -139,110 +139,18 @@ If you use VSCode, we recommend installing the [OCaml Platform](https://marketpl
 
 One can make Ocaml functions available for use in Ltac2 by using the
 foreign function interface (ffi). For now, we gather all such
-definitions in `Wp_ffi.ml`.
+definitions in `wp_ffi.ml`.
 
-Suppose one has an Ocaml function `f : a -> b -> c -> d` where `a, b, c, d` are types, and one would like to make this function available as an Ltac2 tactic.
+Note that with Coq v8.19, using the ffi got a lot easier.
+It may be possible to just look at the examples in `wp_ffi.ml`.
+This process is also explained in [tuto2](https://github.com/rocq-prover/rocq/tree/master/doc/plugin_tutorial/tuto4) of the [Rocq plugin tutorial](https://github.com/rocq-prover/rocq/tree/master/doc/plugin_tutorial).
+The documentation in the file `Tac2externals.mli` may also help.
 
-### Make a tactic
-
-First of all, only tactics can pass the ffi, so one needs to convert `f` into
-something that outputs a tactic. An element of type `'a` can be converted into an `'a`-valued tactic, ie.e. an element of type `'a tactic` by using `tclUNIT`:
-
-Consider this example:
-```
-let my_unit_tactic : unit tactic = tclUNIT ()
-```
-
-```
-let my_bool_tactic : bool tactic = tclUNIT true
-```
-
-Hence, we can convert `f` into something that outputs a tactic by
-
-```
-let my_f_tactic : a -> b -> c -> d tactic =
-  fun input_a input_b input_c -> tclUNIT (f input_a input_b input_c)
-```
-
-### Make a `valexpr` tactic
-
-Datatypes in Ocaml and in Ltac2 need to be translated to each other
-by using an intermediate datatype: namely `valexpr`. This also means that
-only `valexpr`-valued tactics can pass the ffi.
-Luckily, for many types there are already conversion functions available from
-and to `valexpr`, such as `of_bool`, `to_bool` and `of_unit`, `to_unit`.
-In general, these conversions are captured in elements of the type `'a repr`:
-an element `c` of `'a repr` has a conversion `repr_to c : valexpr -> 'a` and
-a conversion `repr_of c : 'a -> valexpr`. For more information, one can look
-at Coq's `tac2ffi.ml` file.
-
-We can then use the strategy from the previous section to make a valexpr tactic.
-```
-let my_valexpr_tactic_from_unit : valexpr tactic = tclUNIT (of_unit ())
-```
-It is common to use the `@@` operator to put everything that comes after it
-in parentheses, so one could also write
-```
-let my_valexpr_tactic_from_unit : valexpr tactic = tclUNIT @@ of_unit ()
-```
-Similarly, here is a `valexpr` tactic created from a `bool`
-```
-let my_valexpr_tactic_from_bool : valexpr tactic = tclUNIT @@ of_bool ()
-```
-
-### Make the function available for the ffi
-
-Considering an example of a function `f : a -> b -> c -> d`, and given
-`a_repr : a repr`, `b_repr : b repr`, `c_repr : c repr`, `d_repr : d repr`, we can
-make this function available for the ffi by
-
-```
-let () = define3 "my_f_external" a_repr b_repr c_repr @@
-  fun input_a, input_b, input_c ->
-    tclUNIT (repr_of d (f input_a input_b input_c))
-```
-
-The `3` is chosen because `f` has `3` inputs.
-
-Note that with some monad magic, the same definition can also be
-achieved by
-```
-let () = define3 "my_f_external" a_repr b_repr c_repr @@
-  fun input_a input_b input_c ->
-    tclUNIT @@ f input_a input_b input_c >>= fun z -> tclUNIT @@ repr_of d z
-```
-Here "my_f_external" is the name by which you can refer to this function
-from Ltac2. Any name can be chosen, and it won't be the name that you use
-to call the function from Ltac2. Representations for many different datatypes
-can be found in Coq's `tac2ffi.ml`. For many datatypes, the respresentation
-of that datatype is called the same: `bool` is for instance the name for `bool repr`, so that the following would be valid code
-
-```
-let () = define1 "my_bool_tactic" bool @@
-  fun input -> tclUNIT input >>= fun z -> tclUNIT @@ of_bool z
-```
-or yet another option
-```
-let () = define1 "my_bool_tactic" bool @@
-  fun input -> tclUNIT input >>= fun z -> tclUNIT @@ repr_of bool z
-```
-
-Note that in Coq v8.19, a new file `tac2externals.ml` was created, which
-can be used to handle a lot of the above issues.
-
-### Make the function available from Ltac2
-
-From a `.v` file, one can simply load
-```
-Require Import Waterproof.Waterproof.
-```
-and then define (in Coq v8.17) (given the caveat below)
-```
-Ltac2 @ external my_f_in_ltac2 : a_ltac2 -> b_ltac2 -> c_ltac2 -> d_ltac2 := "coq-waterproof" "my_f_external".
-```
-where `a_ltac2`, ... `d_ltac2` are the corresponding types on the
-Ltac2 side of the types `a`, ..., `d`. The caveat is that there aren't always
-corresponding types on the Ltac2 side of Ocaml types.
-
-Note that the syntax is a bit different in different versions of Coq.
-Please see the code for examples.
+A few remarks:
+- For passing variables through the ffi, one needs to convert them to an intermediate datatype: namely `valexpr`.
+  For existing datatypes these conversion functions exist and can be used conveniently.
+  With some syntactic sugar from `Tac2externals`, there's really nothing to do.
+  For inductive datatypes, it is relatively easy to create new conversion functions.
+  This process is explained in the tutorial mentioned above.
+- Although this is not really necessary for the ffi anymore, an element of type `'a` can be converted into an `'a`-valued tactic by using `tclUNIT`.
+- To make a tactic available from Ltac2, one needs to use the `Ltac2 @ external` syntax. It may be best to look for examples in the code.

--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -156,11 +156,10 @@ let err (input : Pp.t) : unit Proofview.tactic =
 (**
   Return the last warning
 *)
-let get_last_warning () : Pp.t option Proofview.tactic =
-  Proofview.tclUNIT @@
-    match !(feedback_log Warning) with
-    | [] -> None
-    | hd :: tl -> Some hd
+let get_last_warning () : Pp.t option =
+  match !(feedback_log Warning) with
+| [] -> None
+| hd :: tl -> Some hd
 
 let wp_error_handler (e : exn) : Pp.t option =
   if !filter_errors then

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -112,4 +112,4 @@ val message :
 (**
   Check the last warning against a string
 *)
-val get_last_warning : unit -> Pp.t option Proofview.tactic
+val get_last_warning : unit -> Pp.t option

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -22,9 +22,9 @@
 module Tac2ffi = Ltac2_plugin.Tac2ffi
 module Tac2env = Ltac2_plugin.Tac2env
 module Tac2expr = Ltac2_plugin.Tac2expr
+open Ltac2_plugin.Tac2externals
 
 open Proofview
-open Proofview.Notations
 open Tac2expr
 open Tac2ffi
 open Ltac2_plugin.Tac2val
@@ -37,64 +37,7 @@ open Wp_evars
 (** Creates a name used to define the function interface *)
 let pname (s: string): ml_tactic_name = { mltac_plugin = "rocq-runtime.plugins.coq-waterproof"; mltac_tactic = s }
 
-(** Wrapper around {! Tac2env.define_primitive} to make easier the primitive definition *)
-let define_primitive (name: string) (arity: 'a arity) (f: 'a): unit =
-  Tac2env.define_primitive (pname name) (mk_closure_val arity f)
-
-(**
-  Defines a function of arity 0 (that only takes a [unit] as an argument)
-
-  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: unit := "coq-waterproof" "<name>".]
-*)
-let define0 (name: string) (f: valexpr tactic): unit = define_primitive name arity_one (fun _ -> f)
-
-(**
-  Defines a function of arity 1 (that only takes one argument)
-
-  This function will be callable in Ltac2 with [Ltac2 @ external <ltac2_name>: <type> -> unit := "coq-waterproof" "<name>".]
-*)
-let define1 (name: string) (r0: 'a repr) (f: 'a -> valexpr tactic): unit =
-  define_primitive name arity_one @@ fun x -> f (repr_to r0 x)
-
-(**
-  Defines a function of arity 2 in the same way as {! define1}
-*)
-let define2 (name: string) (r0: 'a repr) (r1: 'b repr) (f: 'a -> 'b -> valexpr tactic): unit =
-  define_primitive name (arity_suc arity_one) @@ fun x y -> f (repr_to r0 x) (repr_to r1 y)
-
-(**
-  Defines a function of arity 3 in the same way as {! define1}
-*)
-let define3 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (f: 'a -> 'b -> 'c -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc arity_one)) @@ fun x y z -> f (repr_to r0 x) (repr_to r1 y) (repr_to r2 z)
-
-(**
-  Defines a function of arity 4 in the same way as {! define1}
-*)
-let define4 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (f: 'a -> 'b -> 'c -> 'd -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc arity_one))) @@
-  fun x0 x1 x2 x3 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3)
-
-(**
-  Defines a function of arity 5 in the same way as {! define1}
-*)
-let define5 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))) @@
-  fun x0 x1 x2 x3 x4 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4)
-
-(**
-  Defines a function of arity 6 in the same way as {! define1}
-*)
-let define6 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one))))) @@
-  fun x0 x1 x2 x3 x4 x5 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5)
-
-(**
-  Defines a function of arity 7 in the same way as {! define1}
-*)
-let define7 (name: string) (r0: 'a repr) (r1: 'b repr) (r2: 'c repr) (r3: 'd repr) (r4: 'e repr) (r5: 'f repr) (r6: 'g repr) (f: 'a -> 'b -> 'c -> 'd -> 'e -> 'f -> 'g -> valexpr tactic): unit =
-  define_primitive name (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc (arity_suc arity_one)))))) @@
-  fun x0 x1 x2 x3 x4 x5 x6 -> f (repr_to r0 x0) (repr_to r1 x1) (repr_to r2 x2) (repr_to r3 x3) (repr_to r4 x4) (repr_to r5 x5) (repr_to r6 x6)
+let define s = Ltac2_plugin.Tac2externals.define (pname s)
 
 (** Comes from [coq/plugins/ltac2/tac2tactics.ml] *)
 let thaw (r: 'a repr) (f: (unit, 'a) fun1): 'a tactic = app_fun1 f unit r ()
@@ -107,7 +50,6 @@ let delayed_of_tactic (tac: 'a tactic) (env: Environ.env) (sigma: Evd.evar_map):
   let _, sigma = Proofview.proofview pv in
   (sigma, c)
 
-
 (**
   Utility function to cast OCaml types into Ltac2-compatibles types
 
@@ -119,21 +61,14 @@ let delayed_of_thunk (r: 'a repr) (tac: (unit, 'a) fun1) (env: Environ.env) (sig
 (** Converts a ['a repr] into a [(unit -> 'a) repr] *)
 let thunk (r: 'a repr): (unit, 'a) fun1 repr = fun1 unit r
 
-let _ = define0
-let _ = define1
-let _ = define2
-let _ = define3
-let _ = define5
-let _ = define7
-
 (** Converts a {! Hint_dataset_declarations.database_type} into a [valexpr] *)
-let database_type_to_valexp (database_type: database_type): valexpr = match database_type with
+let of_database_type (database_type: database_type): valexpr = match database_type with
   | Main -> ValInt 0
   | Decidability -> ValInt 1
   | Shorten -> ValInt 2
 
 (** Converts a [valexpr] into a {! Hint_dataset_declarations.database_type} *)
-let database_type_from_valexp (value: valexpr): database_type = match value with
+let to_database_type (value: valexpr): database_type = match value with
   | ValInt n ->
     let database_type = match n with
       | 0 -> Main
@@ -143,14 +78,10 @@ let database_type_from_valexp (value: valexpr): database_type = match value with
     in database_type
   | _ -> throw (CastError "cannot cast something different than an [int] into a [database_type]")
 
-(* Exports {! Hint_dataset_declarations.database_type} to Ltac2 *)
-let () =
-  define0 "database_type_main" @@ tclUNIT @@ database_type_to_valexp Main;
-  define0 "database_type_decidability" @@ tclUNIT @@ database_type_to_valexp Decidability;
-  define0 "database_type_shorten" @@ tclUNIT @@ database_type_to_valexp Shorten
+let database_type = make_repr of_database_type to_database_type
 
 (** Converts a {! Feedback.level} into a [valexpr] *)
-let feedback_lvl_to_valexpr (feedback_lvl: Feedback.level): valexpr = match feedback_lvl with
+let of_feedback_level (feedback_lvl: Feedback.level): valexpr = match feedback_lvl with
   | Debug -> ValInt (-1)
   | Info -> ValInt 0
   | Notice -> ValInt 1
@@ -158,7 +89,7 @@ let feedback_lvl_to_valexpr (feedback_lvl: Feedback.level): valexpr = match feed
   | Error -> ValInt 3
 
 (** Converts a [valexpr] into a {! Feedback.level} *)
-let feedback_lvl_from_valexpr (value : valexpr): Feedback.level = match value with
+let to_feedback_level (value : valexpr): Feedback.level = match value with
   | ValInt n ->
     let feedback_lvl = match n with
       | -1 -> Feedback.Debug
@@ -170,20 +101,11 @@ let feedback_lvl_from_valexpr (value : valexpr): Feedback.level = match value wi
     in feedback_lvl
   | _ -> throw (CastError "cannot cast something different from an [int] into a [Feedback.level]")
 
-(** Pack the conversion functions for feedback levels into a representation *)
-let feedback_lvl_repr = make_repr feedback_lvl_to_valexpr feedback_lvl_from_valexpr
-
-(** Exports {! Feedback.level} to Ltac2 *)
-let () =
-  define0 "feedback_lvl_debug" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Debug;
-  define0 "feedback_lvl_info" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Info;
-  define0 "feedback_lvl_notice" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Notice;
-  define0 "feedback_lvl_warning" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Warning;
-  define0 "feedback_lvl_error" @@ tclUNIT @@ feedback_lvl_to_valexpr Feedback.Error
+let feedback_level = make_repr of_feedback_level to_feedback_level
 
 (* Exports {! Waterprove.waterprove} to Ltac2 *)
 let () =
-  define4 "waterprove" int bool (list (thunk constr)) (make_repr database_type_to_valexp database_type_from_valexp) @@
+  define "waterprove" (int @-> bool @-> (list (thunk constr)) @-> database_type @-> tac unit) @@
     fun depth shield lems database_type ->
       begin
         waterprove
@@ -191,11 +113,12 @@ let () =
           ~shield
           (List.map (fun lem -> delayed_of_thunk constr lem) lems)
           database_type
-      end >>= fun () -> tclUNIT @@ of_unit ()
+      end
 
 (* Exports {! Waterprove.rwaterprove} to Ltac2 *)
 let () =
-  define6 "rwaterprove" int bool (list (thunk constr)) (make_repr database_type_to_valexp database_type_from_valexp) (list constr) (list constr) @@
+  define "rwaterprove" (int @-> bool @-> (list (thunk constr))
+      @-> database_type @-> list constr @-> list constr @-> tac unit) @@
     fun depth shield lems database_type must_use forbidden ->
       begin
         rwaterprove
@@ -205,56 +128,48 @@ let () =
           database_type
           must_use
           forbidden
-      end >>= fun () -> tclUNIT @@ of_unit ()
+      end
 
 let () =
-  define1 "warn_external" pp @@
-    fun input ->
-      warn input >>= fun () -> tclUNIT @@ of_unit ()
+  define "warn_external" (pp @-> tac unit) @@
+    warn
 
 let () =
-  define1 "notice_external" pp @@
-    fun input ->
-      notice input >>= fun () -> tclUNIT @@ of_unit ()
+  define "notice_external" (pp @-> tac unit) @@
+    notice
 
 let () =
-  define1 "throw_external" pp @@
-    fun input ->
-      err input >>= fun () -> tclUNIT @@ of_unit ()
+  define "throw_external" (pp @-> tac unit) @@
+    err
 
 let () =
-  define1 "inform_external" pp @@
-    fun input ->
-      inform input >>= fun () -> tclUNIT @@ of_unit ()
+  define "inform_external" (pp @-> tac unit) @@
+    inform
 
 let () =
-  define2 "message_external" feedback_lvl_repr pp @@
-    fun lvl input ->
-      message lvl input >>= fun () -> tclUNIT @@ of_unit ()
+  define "message_external" (feedback_level @-> pp @-> (tac unit)) @@
+    message
 
 let () =
-  define1 "refine_goal_with_evar_external" string @@
-    fun input -> refine_goal_with_evar input >>= fun () -> tclUNIT @@ of_unit ()
+  define "refine_goal_with_evar_external" (string @-> tac unit) @@
+    refine_goal_with_evar
 
 let () =
-  define1 "blank_evars_in_term_external" constr @@
-    fun term ->
-      blank_evars_in_term term >>=
-      fun evars -> tclUNIT @@ (of_list of_evar evars)
+  define "blank_evars_in_term_external" (constr @-> tac (list evar)) @@
+    blank_evars_in_term
 
 let () =
-  define1 "get_print_hypothesis_flag_external" unit @@
-    fun input -> tclUNIT @@ of_bool !print_hypothesis_help
+  define "get_print_hypothesis_flag_external" (unit @-> ret bool) @@
+    fun () -> !print_hypothesis_help
 
 let () =
-  define1 "get_redirect_errors_flag_external" unit @@
-    fun input -> tclUNIT @@ of_bool !redirect_errors
+  define "get_redirect_errors_flag_external" (unit @-> ret bool) @@
+    fun () -> !redirect_errors
 
 let () =
-  define1 "get_last_warning_external" unit @@
-    fun input -> get_last_warning input >>=
-      fun pp_option -> tclUNIT @@ of_option of_pp pp_option
+  define "get_last_warning_external" (unit @-> ret (option pp)) @@
+    get_last_warning
 
 let () =
-  define1 "get_feedback_log_external" feedback_lvl_repr @@
-    fun input -> tclUNIT @@ of_list of_pp !(feedback_log input)
+  define "get_feedback_log_external" (feedback_level @-> ret (list pp)) @@
+    fun input -> !(feedback_log input)

--- a/theories/Util/MessagesToUser.v
+++ b/theories/Util/MessagesToUser.v
@@ -27,39 +27,22 @@ Require Import Waterproof.Waterproof.
 Ltac2 fnl () := Message.of_string "
 ".
 
-Local Ltac2 Type feedback_lvl_ffi.
+Ltac2 Type FeedbackLevel := [ Debug | Info | Notice | Warning | Error ].
 
-Ltac2 @ external feedback_lvl_debug_ffi : unit -> feedback_lvl_ffi := "rocq-runtime.plugins.coq-waterproof" "feedback_lvl_debug".
-Ltac2 @ external feedback_lvl_info_ffi : unit -> feedback_lvl_ffi := "rocq-runtime.plugins.coq-waterproof" "feedback_lvl_info".
-Ltac2 @ external feedback_lvl_notice_ffi : unit -> feedback_lvl_ffi := "rocq-runtime.plugins.coq-waterproof" "feedback_lvl_notice".
-Ltac2 @ external feedback_lvl_warning_ffi : unit -> feedback_lvl_ffi := "rocq-runtime.plugins.coq-waterproof" "feedback_lvl_warning".
-Ltac2 @ external feedback_lvl_error_ffi : unit -> feedback_lvl_ffi := "rocq-runtime.plugins.coq-waterproof" "feedback_lvl_error".
-
-Ltac2 @ external send_message_external: feedback_lvl_ffi -> message -> unit := "rocq-runtime.plugins.coq-waterproof" "message_external".
+Ltac2 @ external send_message_external: FeedbackLevel -> message -> unit := "rocq-runtime.plugins.coq-waterproof" "message_external".
 Ltac2 @ external throw_external: message -> unit := "rocq-runtime.plugins.coq-waterproof" "throw_external".
 Ltac2 @ external get_print_hypothesis_flag: unit -> bool := "rocq-runtime.plugins.coq-waterproof" "get_print_hypothesis_flag_external".
 Ltac2 @ external get_redirect_errors_flag : unit -> bool := "rocq-runtime.plugins.coq-waterproof" "get_redirect_errors_flag_external".
 
 Ltac2 @ external get_last_warning : unit -> message option :=
   "rocq-runtime.plugins.coq-waterproof" "get_last_warning_external".
-Ltac2 @ external get_feedback_log_external : feedback_lvl_ffi -> message list :=
+Ltac2 @ external get_feedback_log_external : FeedbackLevel -> message list :=
   "rocq-runtime.plugins.coq-waterproof" "get_feedback_log_external".
-
-Ltac2 Type FeedbackLevel := [ Debug | Info | Notice | Warning | Error ].
-
-Ltac2 feedback_lvl_to_ffi (lvl : FeedbackLevel) :=
-  match lvl with
-  | Debug => feedback_lvl_debug_ffi ()
-  | Info => feedback_lvl_info_ffi ()
-  | Notice => feedback_lvl_notice_ffi ()
-  | Warning => feedback_lvl_warning_ffi ()
-  | Error => feedback_lvl_error_ffi ()
-  end.
 
 Ltac2 Type exn ::= [RedirectedToUserError (message)].
 
 Ltac2 send_message (lvl : FeedbackLevel) (msg : message) :=
-  send_message_external (feedback_lvl_to_ffi lvl) msg.
+  send_message_external lvl msg.
 
 Ltac2 inform (msg : message) :=
   send_message Info msg.
@@ -71,22 +54,22 @@ Ltac2 warn (msg : message) :=
   send_message Warning msg.
 
 Ltac2 get_feedback_log (lvl : FeedbackLevel) :=
-  get_feedback_log_external (feedback_lvl_to_ffi lvl).
+  get_feedback_log_external lvl.
 
 Ltac2 info_notice (msg : message) := inform msg; notice msg.
   (* We send both here because with the right settings in coq-waterproof,
      they show up in different places in the editor. *)
 
-Ltac2 replace_notice (template : string) := 
+Ltac2 replace_notice (template : string) :=
   notice (Message.concat (Message.of_string "Hint, replace with: ") (Message.of_string template)).
 
 (* We slightly abuse the levels here: notice shows up inline and has special treatment to
    work with the templates, inform shows up in the sidebar. *)
-Ltac2 insert_msg (msg : string) (template : string) := 
+Ltac2 insert_msg (msg : string) (template : string) :=
   inform (Message.concat (Message.of_string "Hint, insert: ") (Message.of_string msg));
   notice (Message.concat (Message.of_string "Hint, insert: ") (Message.of_string template)).
 
-Ltac2 replace_msg (msg : string) (template : string) := 
+Ltac2 replace_msg (msg : string) (template : string) :=
   inform (Message.concat (Message.of_string "Hint, replace with: ") (Message.of_string msg));
   replace_notice template.
 

--- a/theories/Waterprove.v
+++ b/theories/Waterprove.v
@@ -30,23 +30,10 @@ Require Import Ltac2.Init.
 
 Require Import Chains.Inequalities.
 
-Local Ltac2 Type database_type_ffi.
-
-Local Ltac2 @ external database_type_main: unit -> database_type_ffi := "rocq-runtime.plugins.coq-waterproof" "database_type_main".
-Local Ltac2 @ external database_type_decidability: unit -> database_type_ffi := "rocq-runtime.plugins.coq-waterproof" "database_type_decidability".
-Local Ltac2 @ external database_type_shorten: unit -> database_type_ffi := "rocq-runtime.plugins.coq-waterproof" "database_type_shorten".
-
-Local Ltac2 @ external waterprove_ffi: int -> bool -> (unit -> constr) list -> database_type_ffi -> unit := "rocq-runtime.plugins.coq-waterproof" "waterprove".
-Local Ltac2 @ external rwaterprove_ffi: int -> bool -> (unit -> constr) list -> database_type_ffi -> constr list -> constr list -> unit := "rocq-runtime.plugins.coq-waterproof" "rwaterprove".
-
 Ltac2 Type database_type := [ Main | Decidability | Shorten ].
 
-Local Ltac2 database_type_to_ffi (db_type: database_type): database_type_ffi :=
-  match db_type with
-    | Main => database_type_main ()
-    | Decidability => database_type_decidability ()
-    | Shorten => database_type_shorten ()
-  end.
+Local Ltac2 @ external waterprove_ffi: int -> bool -> (unit -> constr) list -> database_type -> unit := "rocq-runtime.plugins.coq-waterproof" "waterprove".
+Local Ltac2 @ external rwaterprove_ffi: int -> bool -> (unit -> constr) list -> database_type -> constr list -> constr list -> unit := "rocq-runtime.plugins.coq-waterproof" "rwaterprove".
 
 Open Scope subset_scope.
 
@@ -65,10 +52,10 @@ Close Scope subset_scope.
 
 (** Internal versions of [waterprove] and [rwaterprove]. *)
 Local Ltac2 _waterprove (depth: int) (shield: bool) (lems: (unit -> constr) list) (db_type: database_type): unit  :=
-  waterprove_ffi depth (shield && contains_shielded_pattern ()) lems (database_type_to_ffi db_type).
+  waterprove_ffi depth (shield && contains_shielded_pattern ()) lems db_type.
 
 Local Ltac2 _risky_rwaterprove (depth: int) (shield: bool) (lems: (unit -> constr) list) (db_type: database_type) (must : constr list) (forbidden : constr list) : unit  :=
-  rwaterprove_ffi depth (shield && contains_shielded_pattern ()) lems (database_type_to_ffi db_type) must forbidden.
+  rwaterprove_ffi depth (shield && contains_shielded_pattern ()) lems db_type must forbidden.
 
 
 (** Checks whether [x] is in the current list of hypotheses *)


### PR DESCRIPTION
In Coq v8.19, the ffi mechanism got simplified, as a lot of syntactic sugar was added. Since our minimal version is now 9.0, we can now benefit from this.