### PR TITLE
Fix erroneous conversion of Feedback levels through ffi

### DIFF
--- a/src/exceptions.ml
+++ b/src/exceptions.ml
@@ -179,3 +179,12 @@ let wp_error_handler (e : exn) : Pp.t option =
   else None
 
 let () = CErrors.register_handler wp_error_handler
+
+let check_feedback_level_Ltac2_to_Ocaml (lvl: Feedback.level) (n: int) : bool =
+  match n with
+  | 0 -> lvl == Debug
+  | 1 -> lvl == Info
+  | 2 -> lvl == Notice
+  | 3 -> lvl == Warning
+  | 4 -> lvl == Error
+  | _ -> throw (CastError "Tried to check a feedback level outside range {0,1,2,3,4}")

--- a/src/exceptions.mli
+++ b/src/exceptions.mli
@@ -113,3 +113,8 @@ val message :
   Check the last warning against a string
 *)
 val get_last_warning : unit -> Pp.t option
+
+(**
+  Purely for testing that passing Feedback levels through the ffi works
+*)
+val check_feedback_level_Ltac2_to_Ocaml : Feedback.level -> int -> bool

--- a/src/wp_ffi.ml
+++ b/src/wp_ffi.ml
@@ -82,22 +82,22 @@ let database_type = make_repr of_database_type to_database_type
 
 (** Converts a {! Feedback.level} into a [valexpr] *)
 let of_feedback_level (feedback_lvl: Feedback.level): valexpr = match feedback_lvl with
-  | Debug -> ValInt (-1)
-  | Info -> ValInt 0
-  | Notice -> ValInt 1
-  | Warning -> ValInt 2
-  | Error -> ValInt 3
+  | Debug -> ValInt 0
+  | Info -> ValInt 1
+  | Notice -> ValInt 2
+  | Warning -> ValInt 3
+  | Error -> ValInt 4
 
 (** Converts a [valexpr] into a {! Feedback.level} *)
 let to_feedback_level (value : valexpr): Feedback.level = match value with
   | ValInt n ->
     let feedback_lvl = match n with
-      | -1 -> Feedback.Debug
-      | 0 -> Info
-      | 1 -> Notice
-      | 2 -> Warning
-      | 3 -> Error
-      | _ -> throw (CastError "cannot cast an [int] outside {-1, 0, 1, 2, 3} into a [Feedback.level]")
+      | 0 -> Feedback.Debug
+      | 1 -> Info
+      | 2 -> Notice
+      | 3 -> Warning
+      | 4 -> Error
+      | _ -> throw (CastError "cannot cast an [int] outside {0, 1, 2, 3, 4} into a [Feedback.level]")
     in feedback_lvl
   | _ -> throw (CastError "cannot cast something different from an [int] into a [Feedback.level]")
 
@@ -175,3 +175,11 @@ let () =
 let () =
   define "get_feedback_log_external" (feedback_level @-> ret (list pp)) @@
     fun input -> !(feedback_log input)
+
+let () =
+  define "check_feedback_level_Ltac2_to_Ocaml_external" (feedback_level @-> int @-> ret bool) @@
+    check_feedback_level_Ltac2_to_Ocaml
+
+let () =
+  define "feedback_level_round_trip_external" (feedback_level @-> ret feedback_level) @@
+    fun input -> input

--- a/tests/util/MessagesToUser.v
+++ b/tests/util/MessagesToUser.v
@@ -42,4 +42,39 @@ Goal False.
 assert_is_false (get_print_hypothesis_flag ()).
 Abort.
 
+(** Test whether feedback levels are correctly passed through the ffi. *)
+Ltac2 @ external check_feedback_level_Ltac2_to_Ocaml_ffi : FeedbackLevel -> int -> bool := "rocq-runtime.plugins.coq-waterproof" "check_feedback_level_Ltac2_to_Ocaml_external".
 
+Goal False.
+assert_is_true (check_feedback_level_Ltac2_to_Ocaml_ffi Debug 0).
+assert_is_true (check_feedback_level_Ltac2_to_Ocaml_ffi Info 1).
+assert_is_true (check_feedback_level_Ltac2_to_Ocaml_ffi Notice 2).
+assert_is_true (check_feedback_level_Ltac2_to_Ocaml_ffi Warning 3).
+assert_is_true (check_feedback_level_Ltac2_to_Ocaml_ffi Error 4).
+Abort.
+
+(** Test a round-trip of feedback levels *)
+Ltac2 @ external feedback_level_round_trip_ffi : FeedbackLevel -> FeedbackLevel := "rocq-runtime.plugins.coq-waterproof" "feedback_level_round_trip_external".
+
+Goal False.
+match feedback_level_round_trip_ffi Debug with
+| Debug => ()
+| _ => Control.throw (TestFailedError (Message.of_string "Debug did not round-trip correctly."))
+end.
+match feedback_level_round_trip_ffi Info with
+| Info => ()
+| _ => Control.throw (TestFailedError (Message.of_string "Info did not round-trip correctly."))
+end.
+match feedback_level_round_trip_ffi Notice with
+| Notice => ()
+| _ => Control.throw (TestFailedError (Message.of_string "Notice did not round-trip correctly."))
+end.
+match feedback_level_round_trip_ffi Warning with
+| Warning => ()
+| _ => Control.throw (TestFailedError (Message.of_string "Warning did not round-trip correctly."))
+end.
+match feedback_level_round_trip_ffi Error with
+| Error => ()
+| _ => Control.throw (TestFailedError (Message.of_string "Error did not round-trip correctly."))
+end.
+Abort.


### PR DESCRIPTION
We used a wrong conversion for feedback levels through the ffi.

Please look at the added tests whether they would have fished out this bug.

For additional instructions, please see this [tutorial](https://github.com/rocq-prover/rocq/tree/master/doc/plugin_tutorial/tuto4).