### PR TITLE
No longer throw an error if there are unused lemmas

### DIFF
--- a/tests/automation/Chains.v
+++ b/tests/automation/Chains.v
@@ -23,6 +23,12 @@ Require Import Waterproof.Notations.
 
 Require Import Waterproof.Waterprove.
 
+Require Import Waterproof.Util.MessagesToUser.
+Require Import Waterproof.Util.Assertions.
+
+Waterproof Enable Logging.
+Waterproof Enable Redirect Errors.
+Waterproof Enable Redirect Feedback.
 
 (** Tests whether the error points out which specific (in)equality in the chain does not hold. *)
 Local Parameter X : Type.
@@ -72,11 +78,4 @@ Goal P -> (& b = b = a = b = b = a = a).
 Proof.
   intro H.
   rwaterprove 5 true Main [constr:(h)] [].
-Abort.
-
-(* Test 7: Fails if extra lemma is never used. *)
-Goal P -> (P -> b = c) -> (& b = b = c = b = b = c = c).
-Proof.
-  intros H1 H2.
-  Fail rwaterprove 5 true Main [constr:(h)] [].
 Abort.

--- a/tests/tactics/Conclusion.v
+++ b/tests/tactics/Conclusion.v
@@ -139,9 +139,8 @@ Lemma test_by_we_conclude_5: 1 < 2.
 Proof.
     assert (useless: 1 = 1).
     reflexivity.
-    assert_fails_with_string
-    (fun () => By test_by_we_conclude_1 we conclude that (1 < 2))
-"Could not verify this follows from the provided reasons.".
+    assert_feedback_with_strings (fun () => By test_by_we_conclude_1 we conclude that (1 < 2)) Info
+    ["It may be that the provided reason test_by_we_conclude_1 is not necessary for the proof."].
 Abort.
 
 (** Additional tests 'By ...' clause.  *)
@@ -179,7 +178,10 @@ Abort.
 Goal A -> B.
   intro H.
   pose f.
-  Fail By g we conclude that B.
+  assert_feedback_with_strings
+    (fun () => By g we conclude that B)
+    Info
+    ["It may be that the provided reason g is not necessary for the proof."].
 Abort.
 
 
@@ -373,7 +375,8 @@ Qed.
 
 Goal U -> R.
 intro H.
-assert_fails_with_string
+assert_feedback_with_strings
   (fun () => By my reason, my other reason, HPQ, HQR and HRT we conclude that R)
-  "Could not verify this follows from the provided reasons.".
+  Info
+  ["It may be that the provided reason HRT is not necessary for the proof."].
 Abort.

--- a/tests/tactics/ItHolds.v
+++ b/tests/tactics/ItHolds.v
@@ -29,6 +29,10 @@ Require Import Waterproof.Notations.Sets.
 Require Import Waterproof.Util.Assertions.
 Require Import Waterproof.Util.MessagesToUser.
 
+Waterproof Enable Redirect Errors.
+Waterproof Enable Redirect Feedback.
+Waterproof Enable Logging.
+
 Waterproof Enable Automation RealsAndIntegers.
 
 (* lra only works in the [R_scope] *)
@@ -201,7 +205,9 @@ Goal A -> False.
 Proof.
   intro H.
   pose f.
-  Fail By g it holds that B.
+  assert_feedback_with_strings (fun () => By g it holds that B)
+  Info
+  ["It may be that the provided reason g is not necessary for the proof."].
 Abort.
 
 (** Tests for 'Since ...' clause. *)
@@ -426,14 +432,14 @@ By H, Hab and Hbc it holds that c.
 Abort.
 
 Waterproof Enable Redirect Errors.
-Waterproof Enable Logging.
 
 (** Test 31: Multiple hypotheses, mention hypothesis that is not useful *)
 
 Goal a -> b.
 Proof.
-assert_fails_with_string (fun () => By Ha, Hab and Hbc it holds that b)
-"Could not verify this follows from the provided reasons.".
+assert_feedback_with_strings (fun () => By Ha, Hab and Hbc it holds that b)
+Info
+  ["It may be that the provided reason Hbc is not necessary for the proof."].
 Abort.
 
 Local Parameter d : Prop.

--- a/tests/tactics/ItSuffices.v
+++ b/tests/tactics/ItSuffices.v
@@ -22,6 +22,7 @@ Require Import Ltac2.Message.
 Require Import Waterproof.Waterproof.
 Require Import Waterproof.Automation.
 Require Import Waterproof.Tactics.
+Require Import Waterproof.Util.MessagesToUser.
 Require Import Waterproof.Util.Assertions.
 
 (* -------------------------------------------------------------------------- *)
@@ -204,11 +205,12 @@ Abort.
 (** Test 20: Fails when one of the reasons is not helpful *)
 
 Waterproof Enable Logging.
-Waterproof Enable Redirect Errors.
+Waterproof Enable Redirect Feedback.
 
 Goal R.
-assert_fails_with_string
+assert_feedback_with_strings
   (fun () => By my reason, my other reason,
     HPQ, HQR and HRT it suffices to show that U)
-  "Could not verify this follows from the provided reasons.".
+  Info
+  ["It may be that the provided reason HRT is not necessary for the proof."].
 Abort.


### PR DESCRIPTION
Before, if we noticed that there were unused lemmas in the automation procedure, we would throw an error/exception and continue our search. This has now been replaced by an Info message.

In the automation routine, we now no longer run the automation twice when a `By ...  it holds that` statement fails.

When proving an inequality chain, we no longer check whether all lemmas are used at all. We may want to change this in the future again, but for now it would complicate the logic too much in my opinion.

## Testing the pull request:

It is important to try running the renewed automation against the exercises.