### PR TITLE
Fix compilation.

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -1,7 +1,6 @@
 (coq.theory
   (name __WaterproofTests)
   (package coq-waterproof)
-  (flags :standard -warn-error -3)
   (plugins coq-waterproof.plugin rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2)
   (theories Waterproof))
 

--- a/theories/dune
+++ b/theories/dune
@@ -1,7 +1,6 @@
 (coq.theory
  (name Waterproof)
  (package coq-waterproof)
- (flags :standard -warn-error -3)
  (theories Stdlib Ltac2)
  (plugins coq-waterproof.plugin rocq-runtime.plugins.ltac rocq-runtime.plugins.ltac2))
 


### PR DESCRIPTION
The flags field for coq theories is referring to the Rocq flags, not the OCaml ones.