### PR TITLE
Rely on more robust APIs to generate global rewrite hints.

### DIFF
--- a/src/wp_rewrite.ml
+++ b/src/wp_rewrite.ml
@@ -381,10 +381,11 @@ let print_rewrite_hintdb (env: Environ.env) (sigma: Evd.evar_map) (rewrite_datab
 *)
 let to_raw_rew_rule (env: Environ.env) (sigma: Evd.evar_map) (hyp: Constrexpr.constr_expr): raw_rew_rule =
   let econstr, context = Constrintern.interp_constr env sigma hyp in
+  let sigma = Evd.from_ctx context in
+  let sigma = Evd.collapse_sort_variables sigma in
   let constr = EConstr.to_constr sigma econstr in
-  let univ_ctx = UState.context_set context in
-  let () = Global.push_qualities QGraph.Internal (PConstraints.ContextSet.sort_context_set univ_ctx) in (* XXX *)
-  let () = Global.push_context_set (PConstraints.ContextSet.univ_context_set univ_ctx) in
+  let uctx = Evd.universe_context_set sigma in
+  let () = Global.push_context_set uctx in
   CAst.make ?loc:(Constrexpr_ops.constr_loc hyp) (constr, true, Option.map (in_gen (rawwit wit_ltac)) None)
 
 (**


### PR DESCRIPTION
We do not try to be clever with qualities, but instead collapse them all to Type. This also removes the last bits of PConstraints.ContextSet.t.